### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.1.0] - 2023-03-06
+
 ### Added
 
 - Initial implementation.


### PR DESCRIPTION
The first release of the CNB to Docker Hub + the upstream CNB Buildpack Registry.

GUS-W-12614519.