### PR TITLE
Skip the GitHub release creation step in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,13 +68,14 @@ jobs:
           id: ${{ env.buildpack_id }}
           version: ${{ env.buildpack_version }}
           address: ${{ env.BUILDPACK_DOCKER_REPO }}@${{ env.buildpack_digest }}
-      - name: Create GitHub release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ env.buildpack_version }}
-          release_name: v${{ env.buildpack_version }}
-          body: |
-            See the [CHANGELOG](./CHANGELOG.md) for details.
-          draft: false
+      # Skipped for now since the step fails due to IP allowlisting.
+      # - name: Create GitHub release
+      #   uses: actions/create-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     tag_name: v${{ env.buildpack_version }}
+      #     release_name: v${{ env.buildpack_version }}
+      #     body: |
+      #       See the [CHANGELOG](./CHANGELOG.md) for details.
+      #     draft: false


### PR DESCRIPTION
Since the step currently fails due to the IP allowlisting restrictions.

See the [Slack discussion](https://salesforce-internal.slack.com/archives/C02GZCPPV38/p1678104010048029).

GUS-W-12614519.