### PR TITLE
Update setuptools to 67.6.1 and wheel to 0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The default Python version is now 3.11.3 (previously 3.11.2).
+- The default Python version is now 3.11.3 (previously 3.11.2). ([#22](https://github.com/heroku/buildpacks-python/pull/22))
+- Updated setuptools from 67.5.0 to 67.6.1. ([#24](https://github.com/heroku/buildpacks-python/pull/24))
+- Updated wheel from 0.38.4 to 0.40.0. ([#24](https://github.com/heroku/buildpacks-python/pull/24))
 
 ## [0.1.0] - 2023-03-06
 
 ### Added
 
-- Initial implementation.
+- Initial implementation. ([#3](https://github.com/heroku/buildpacks-python/pull/3))

--- a/src/packaging_tool_versions.rs
+++ b/src/packaging_tool_versions.rs
@@ -15,8 +15,8 @@ impl Default for PackagingToolVersions {
     fn default() -> Self {
         Self {
             pip_version: "23.0.1".to_string(),
-            setuptools_version: "67.5.0".to_string(),
-            wheel_version: "0.38.4".to_string(),
+            setuptools_version: "67.6.1".to_string(),
+            wheel_version: "0.40.0".to_string(),
         }
     }
 }


### PR DESCRIPTION
- Setuptools has been updated from 67.5.0 to 67.6.1.
- Wheel has been updated from 0.38.4 to 0.40.0.

Changes:
https://setuptools.pypa.io/en/stable/history.html#v67-6-1
https://wheel.readthedocs.io/en/stable/news.html

GUS-W-13011118.
GUS-W-13011108.