### PR TITLE
Adjust the messaging shown when the Python layer cache is invalidated

### DIFF
--- a/tests/integration/pip.rs
+++ b/tests/integration/pip.rs
@@ -122,7 +122,8 @@ fn cache_discarded_on_python_version_change() {
                     Using Python version {LATEST_PYTHON_3_11} specified in runtime.txt
                     
                     [Installing Python and packaging tools]
-                    Discarding cache since the Python version has changed from {LATEST_PYTHON_3_10} to {LATEST_PYTHON_3_11}
+                    Discarding cache since:
+                     - The Python version has changed from {LATEST_PYTHON_3_10} to {LATEST_PYTHON_3_11}
                     Installing Python {LATEST_PYTHON_3_11}
                     Installing pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
                     
@@ -166,7 +167,8 @@ fn cache_discarded_on_stack_change() {
                     To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
                     
                     [Installing Python and packaging tools]
-                    Discarding cache since the stack has changed from heroku-20 to heroku-22
+                    Discarding cache since:
+                     - The stack has changed from heroku-20 to heroku-22
                     Installing Python {DEFAULT_PYTHON_VERSION}
                     Installing pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
                     
@@ -209,8 +211,8 @@ fn cache_discarded_on_multiple_changes() {
                     
                     [Installing Python and packaging tools]
                     Discarding cache since:
-                     - the stack has changed from heroku-20 to heroku-22
-                     - the Python version has changed from {LATEST_PYTHON_3_10} to {LATEST_PYTHON_3_11}
+                     - The stack has changed from heroku-20 to heroku-22
+                     - The Python version has changed from {LATEST_PYTHON_3_10} to {LATEST_PYTHON_3_11}
                     Installing Python {LATEST_PYTHON_3_11}
                     Installing pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
                     


### PR DESCRIPTION
* The messaging now always uses a bulleted style, rather than only doing so when there is more than one reason. (For consistency, to make the invalidation stand out more in the logs, and to remove the awkward split of the message prefix across two functions.)
* The reason bullets are now capitalised

GUS-W-13174471.