### PR TITLE
Speed up the integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,14 @@ jobs:
         uses: Swatinem/rust-cache@v2.2.1
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.1.0
-      - name: Run integration tests
-        # Runs only tests annotated with the `ignore` attribute (which in this repo, are the integration tests).
+      - name: Pull builder image
+        run: docker pull ${{ env.INTEGRATION_TEST_CNB_BUILDER }}
+      # The integration tests are annotated with the `ignore` attribute, allowing us to run
+      # only those and not the unit tests, via the `--ignored` option. On the latest stack
+      # we run all integration tests, but on older stacks we only run stack-specific tests.
+      - name: Run integration tests (all tests)
+        if: matrix.builder == 'builder:22'
         run: cargo test --locked -- --ignored --test-threads 5
+      - name: Run integration tests (stack-specific tests only)
+        if: matrix.builder != 'builder:22'
+        run: cargo test --locked -- --ignored --test-threads 5 'python_version::'

--- a/tests/fixtures/pip_basic/requirements.txt
+++ b/tests/fixtures/pip_basic/requirements.txt
@@ -1,0 +1,2 @@
+# This package has been picked since it has no dependencies and is small/fast to install.
+typing-extensions==4.4.0

--- a/tests/fixtures/pip_editable_git_compiled/requirements.txt
+++ b/tests/fixtures/pip_editable_git_compiled/requirements.txt
@@ -2,8 +2,7 @@
 #  - Git from the stack image can be found (ie: the system PATH has been correctly propagated to pip).
 #  - The editable mode repository clone is saved into the dependencies layer (via the `--src` option).
 #
-# The psycopg2 package is used instead of a pure Python package, in order to test that:
-#  - The Python headers can be found in the `include/pythonX.Y/` directory of the Python layer.
-#  - Headers/libraries from the stack image can be found (in this case, for libpq-dev).
+# A C-based package is used instead of a pure Python package, in order to test that the
+# Python headers can be found in the `include/pythonX.Y/` directory of the Python layer.
 
--e git+https://github.com/psycopg/psycopg2@2_9_5#egg=psycopg2
+-e git+https://github.com/pypa/wheel@0.40.0#egg=extension.dist&subdirectory=tests/testdata/extension.dist

--- a/tests/fixtures/python_3.10/requirements.txt
+++ b/tests/fixtures/python_3.10/requirements.txt
@@ -1,2 +1,0 @@
-# This package has been picked since it has no dependencies and is small/fast to install.
-typing-extensions==4.4.0

--- a/tests/fixtures/python_3.11/requirements.txt
+++ b/tests/fixtures/python_3.11/requirements.txt
@@ -1,2 +1,0 @@
-# This package has been picked since it has no dependencies and is small/fast to install.
-typing-extensions==4.4.0

--- a/tests/fixtures/python_3.7/requirements.txt
+++ b/tests/fixtures/python_3.7/requirements.txt
@@ -1,2 +1,0 @@
-# This package has been picked since it has no dependencies and is small/fast to install.
-typing-extensions==4.4.0

--- a/tests/fixtures/python_3.8/requirements.txt
+++ b/tests/fixtures/python_3.8/requirements.txt
@@ -1,2 +1,0 @@
-# This package has been picked since it has no dependencies and is small/fast to install.
-typing-extensions==4.4.0

--- a/tests/fixtures/python_3.9/requirements.txt
+++ b/tests/fixtures/python_3.9/requirements.txt
@@ -1,2 +1,0 @@
-# This package has been picked since it has no dependencies and is small/fast to install.
-typing-extensions==4.4.0

--- a/tests/fixtures/python_version_unspecified/requirements.txt
+++ b/tests/fixtures/python_version_unspecified/requirements.txt
@@ -1,2 +1,0 @@
-# This package has been picked since it has no dependencies and is small/fast to install.
-typing-extensions==4.4.0

--- a/tests/integration/detect.rs
+++ b/tests/integration/detect.rs
@@ -1,36 +1,21 @@
 use crate::integration_tests::builder;
-use indoc::formatdoc;
-use libcnb::data::buildpack::{BuildpackVersion, SingleBuildpackDescriptor};
+use indoc::indoc;
 use libcnb_test::{assert_contains, BuildConfig, PackResult, TestRunner};
-use std::fs;
 
 #[test]
 #[ignore = "integration test"]
 fn detect_rejects_non_python_projects() {
-    let buildpack_version = buildpack_version();
-
     TestRunner::default().build(
         BuildConfig::new(builder(), "tests/fixtures/empty")
             .expected_pack_result(PackResult::Failure),
         |context| {
             assert_contains!(
                 context.pack_stdout,
-                &formatdoc! {"
-                    ===> DETECTING
-                    ======== Output: heroku/python@{buildpack_version} ========
+                indoc! {"========
                     No Python project files found (such as requirements.txt).
                     ======== Results ========
-                    fail: heroku/python@{buildpack_version}
-                    ERROR: No buildpack groups passed detection.
                 "}
             );
         },
     );
-}
-
-fn buildpack_version() -> BuildpackVersion {
-    let buildpack_toml = fs::read_to_string("buildpack.toml").unwrap();
-    let buildpack_descriptor =
-        toml::from_str::<SingleBuildpackDescriptor<Option<()>>>(&buildpack_toml).unwrap();
-    buildpack_descriptor.buildpack.version
 }

--- a/tests/integration/pip.rs
+++ b/tests/integration/pip.rs
@@ -1,74 +1,71 @@
-use crate::integration_tests::{
-    builder, DEFAULT_PYTHON_VERSION, LATEST_PYTHON_3_10, LATEST_PYTHON_3_11,
-};
+use crate::integration_tests::{builder, DEFAULT_PYTHON_VERSION};
 use crate::packaging_tool_versions::PackagingToolVersions;
-use indoc::formatdoc;
-use libcnb_test::{assert_contains, assert_empty, BuildConfig, PackResult, TestRunner};
+use indoc::{formatdoc, indoc};
+use libcnb_test::{
+    assert_contains, assert_empty, BuildConfig, BuildpackReference, PackResult, TestRunner,
+};
 
 #[test]
 #[ignore = "integration test"]
-fn pip_editable_git_compiled() {
-    // This tests that:
-    //  - Git from the stack image can be found (ie: the system PATH has been correctly propagated to pip).
-    //  - The editable mode repository clone is saved into the dependencies layer not the app dir.
-    //  - Compiling a source distribution package (as opposed to a pre-built wheel) works.
-    //  - The Python headers can be found in the `include/pythonX.Y/` directory of the Python layer.
-    //  - Headers/libraries from the stack image can be found (in this case, for libpq-dev).
-    TestRunner::default().build(
-        BuildConfig::new(builder(), "tests/fixtures/pip_editable_git_compiled"),
-        |context| {
-            assert_contains!(
-                context.pack_stdout,
-                "Cloning https://github.com/psycopg/psycopg2 (to revision 2_9_5) to /layers/heroku_python/dependencies/src/psycopg2"
-            );
-        },
-    );
-}
-
-#[test]
-#[ignore = "integration test"]
-fn pip_install_error() {
-    TestRunner::default().build(
-        BuildConfig::new(builder(), "tests/fixtures/pip_invalid_requirement")
-            .expected_pack_result(PackResult::Failure),
-        |context| {
-            // Ideally we could test a combined stdout/stderr, however libcnb-test doesn't support this:
-            // https://github.com/heroku/libcnb.rs/issues/536
-            assert_contains!(
-                context.pack_stdout,
-                &formatdoc! {"
-                    [Installing dependencies using Pip]
-                    Running pip install
-                "}
-            );
-            assert_contains!(
-                context.pack_stderr,
-                &formatdoc! {"
-                    ERROR: Invalid requirement: 'an-invalid-requirement!' (from line 1 of requirements.txt)
-                    
-                    [Error: Unable to install dependencies using pip]
-                    The 'pip install' command to install the application's dependencies from
-                    'requirements.txt' failed (exit status: 1).
-                    
-                    See the log output above for more information.
-                "}
-            );
-        },
-    );
-}
-
-#[test]
-#[ignore = "integration test"]
-fn cache_used_for_repeat_builds() {
+fn pip_basic_install_and_cache_reuse() {
     let PackagingToolVersions {
         pip_version,
         setuptools_version,
         wheel_version,
     } = PackagingToolVersions::default();
 
-    let config = BuildConfig::new(builder(), "tests/fixtures/python_3.11");
+    let config = BuildConfig::new(builder(), "tests/fixtures/pip_basic");
 
     TestRunner::default().build(&config, |context| {
+        assert_empty!(context.pack_stderr);
+        assert_contains!(
+            context.pack_stdout,
+            &formatdoc! {"
+                ===> BUILDING
+                
+                [Determining Python version]
+                No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
+                To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
+                
+                [Installing Python and packaging tools]
+                Installing Python {DEFAULT_PYTHON_VERSION}
+                Installing pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
+                
+                [Installing dependencies using Pip]
+                Running pip install
+                Collecting typing-extensions==4.4.0 (from -r requirements.txt (line 2))
+                  Downloading typing_extensions-4.4.0-py3-none-any.whl (26 kB)
+                Installing collected packages: typing-extensions
+                Successfully installed typing-extensions-4.4.0
+                ===> EXPORTING
+            "}
+        );
+
+        // Check that:
+        // - Pip is available at runtime too (and not just during the build).
+        // - The correct versions of pip/setuptools/wheel were installed.
+        // - Pip uses (via 'PYTHONUSERBASE') the user site-packages in the dependencies
+        //   layer, and so can find the typing-extensions package installed there.
+        // - The "pip update available" warning is not shown (since it should be suppressed).
+        // - The system site-packages directory is protected against running 'pip install'
+        //   without having passed '--user'.
+        let command_output =
+            context.run_shell_command("pip list && pip install --dry-run typing-extensions");
+        assert_empty!(command_output.stderr);
+        assert_contains!(
+            command_output.stdout,
+            &formatdoc! {"
+                Package           Version
+                ----------------- -------
+                pip               {pip_version}
+                setuptools        {setuptools_version}
+                typing_extensions 4.4.0
+                wheel             {wheel_version}
+                Defaulting to user installation because normal site-packages is not writeable
+                Requirement already satisfied: typing-extensions in /layers/heroku_python/dependencies/lib/"
+            }
+        );
+
         context.rebuild(&config, |rebuild_context| {
             assert_empty!(rebuild_context.pack_stderr);
             assert_contains!(
@@ -77,10 +74,11 @@ fn cache_used_for_repeat_builds() {
                     ===> BUILDING
                     
                     [Determining Python version]
-                    Using Python version {LATEST_PYTHON_3_11} specified in runtime.txt
+                    No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
+                    To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
                     
                     [Installing Python and packaging tools]
-                    Using cached Python {LATEST_PYTHON_3_11}
+                    Using cached Python {DEFAULT_PYTHON_VERSION}
                     Using cached pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
                     
                     [Installing dependencies using Pip]
@@ -97,135 +95,107 @@ fn cache_used_for_repeat_builds() {
     });
 }
 
+// This tests that:
+// - The cached layers are correctly invalidated when Python/other versions change.
+// - The layer metadata written by older versions of the buildpack are still compatible.
 #[test]
 #[ignore = "integration test"]
-fn cache_discarded_on_python_version_change() {
+fn pip_cache_invalidation_and_metadata_compatibility() {
     let PackagingToolVersions {
         pip_version,
         setuptools_version,
         wheel_version,
     } = PackagingToolVersions::default();
 
-    let builder = builder();
-    let config_before = BuildConfig::new(&builder, "tests/fixtures/python_3.10");
-    let config_after = BuildConfig::new(&builder, "tests/fixtures/python_3.11");
+    let config = BuildConfig::new(builder(), "tests/fixtures/pip_basic");
 
-    TestRunner::default().build(config_before, |context| {
-        context.rebuild(config_after, |rebuild_context| {
-            assert_empty!(rebuild_context.pack_stderr);
+    TestRunner::default().build(
+        config.clone().buildpacks(vec![BuildpackReference::Other(
+            "docker://docker.io/heroku/buildpack-python:0.1.0".to_string(),
+        )]),
+        |context| {
+            context.rebuild(config, |rebuild_context| {
+                assert_empty!(rebuild_context.pack_stderr);
+                assert_contains!(
+                    rebuild_context.pack_stdout,
+                    &formatdoc! {"
+                        ===> BUILDING
+                        
+                        [Determining Python version]
+                        No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
+                        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
+                        
+                        [Installing Python and packaging tools]
+                        Discarding cache since:
+                         - The Python version has changed from 3.11.2 to {DEFAULT_PYTHON_VERSION}
+                         - The pip version has changed from 23.0.1 to {pip_version}
+                         - The setuptools version has changed from 67.5.0 to {setuptools_version}
+                         - The wheel version has changed from 0.38.4 to {wheel_version}
+                        Installing Python {DEFAULT_PYTHON_VERSION}
+                        Installing pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
+                        
+                        [Installing dependencies using Pip]
+                        Discarding cached pip download/wheel cache
+                        Running pip install
+                        Collecting typing-extensions==4.4.0 (from -r requirements.txt (line 2))
+                          Downloading typing_extensions-4.4.0-py3-none-any.whl (26 kB)
+                        Installing collected packages: typing-extensions
+                        Successfully installed typing-extensions-4.4.0
+                        ===> EXPORTING
+                    "}
+                );
+            });
+        },
+    );
+}
+
+// This tests that:
+//  - Git from the stack image can be found (ie: the system PATH has been correctly propagated to pip).
+//  - The editable mode repository clone is saved into the dependencies layer not the app dir.
+//  - Compiling a source distribution package (as opposed to a pre-built wheel) works.
+//  - The Python headers can be found in the `include/pythonX.Y/` directory of the Python layer.
+#[test]
+#[ignore = "integration test"]
+fn pip_editable_git_compiled() {
+    TestRunner::default().build(
+        BuildConfig::new(builder(), "tests/fixtures/pip_editable_git_compiled"),
+        |context| {
             assert_contains!(
-                rebuild_context.pack_stdout,
-                &formatdoc! {"
-                    ===> BUILDING
-                    
-                    [Determining Python version]
-                    Using Python version {LATEST_PYTHON_3_11} specified in runtime.txt
-                    
-                    [Installing Python and packaging tools]
-                    Discarding cache since:
-                     - The Python version has changed from {LATEST_PYTHON_3_10} to {LATEST_PYTHON_3_11}
-                    Installing Python {LATEST_PYTHON_3_11}
-                    Installing pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
-                    
-                    [Installing dependencies using Pip]
-                    Discarding cached pip download/wheel cache
-                    Running pip install
-                    Collecting typing-extensions==4.4.0 (from -r requirements.txt (line 2))
-                      Downloading typing_extensions-4.4.0-py3-none-any.whl (26 kB)
-                    Installing collected packages: typing-extensions
-                    Successfully installed typing-extensions-4.4.0
-                    ===> EXPORTING
-                "}
+                context.pack_stdout,
+                "Cloning https://github.com/pypa/wheel (to revision 0.40.0) to /layers/heroku_python/dependencies/src/extension-dist"
             );
-        });
-    });
+        },
+    );
 }
 
 #[test]
 #[ignore = "integration test"]
-fn cache_discarded_on_stack_change() {
-    let PackagingToolVersions {
-        pip_version,
-        setuptools_version,
-        wheel_version,
-    } = PackagingToolVersions::default();
-
-    let fixture = "tests/fixtures/python_version_unspecified";
-    let config_before = BuildConfig::new("heroku/buildpacks:20", fixture);
-    let config_after = BuildConfig::new("heroku/builder:22", fixture);
-
-    TestRunner::default().build(config_before, |context| {
-        context.rebuild(config_after, |rebuild_context| {
-            assert_empty!(rebuild_context.pack_stderr);
+fn pip_install_error() {
+    TestRunner::default().build(
+        BuildConfig::new(builder(), "tests/fixtures/pip_invalid_requirement")
+            .expected_pack_result(PackResult::Failure),
+        |context| {
+            // Ideally we could test a combined stdout/stderr, however libcnb-test doesn't support this:
+            // https://github.com/heroku/libcnb.rs/issues/536
             assert_contains!(
-                rebuild_context.pack_stdout,
-                &formatdoc! {"
-                    ===> BUILDING
-                    
-                    [Determining Python version]
-                    No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
-                    To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
-                    
-                    [Installing Python and packaging tools]
-                    Discarding cache since:
-                     - The stack has changed from heroku-20 to heroku-22
-                    Installing Python {DEFAULT_PYTHON_VERSION}
-                    Installing pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
-                    
+                context.pack_stdout,
+                indoc! {"
                     [Installing dependencies using Pip]
-                    Discarding cached pip download/wheel cache
                     Running pip install
-                    Collecting typing-extensions==4.4.0 (from -r requirements.txt (line 2))
-                      Downloading typing_extensions-4.4.0-py3-none-any.whl (26 kB)
-                    Installing collected packages: typing-extensions
-                    Successfully installed typing-extensions-4.4.0
-                    ===> EXPORTING
                 "}
             );
-        });
-    });
-}
-
-#[test]
-#[ignore = "integration test"]
-fn cache_discarded_on_multiple_changes() {
-    let PackagingToolVersions {
-        pip_version,
-        setuptools_version,
-        wheel_version,
-    } = PackagingToolVersions::default();
-
-    let config_before = BuildConfig::new("heroku/buildpacks:20", "tests/fixtures/python_3.10");
-    let config_after = BuildConfig::new("heroku/builder:22", "tests/fixtures/python_3.11");
-
-    TestRunner::default().build(config_before, |context| {
-        context.rebuild(config_after, |rebuild_context| {
-            assert_empty!(rebuild_context.pack_stderr);
             assert_contains!(
-                rebuild_context.pack_stdout,
-                &formatdoc! {"
-                    ===> BUILDING
+                context.pack_stderr,
+                indoc! {"
+                    ERROR: Invalid requirement: 'an-invalid-requirement!' (from line 1 of requirements.txt)
                     
-                    [Determining Python version]
-                    Using Python version {LATEST_PYTHON_3_11} specified in runtime.txt
+                    [Error: Unable to install dependencies using pip]
+                    The 'pip install' command to install the application's dependencies from
+                    'requirements.txt' failed (exit status: 1).
                     
-                    [Installing Python and packaging tools]
-                    Discarding cache since:
-                     - The stack has changed from heroku-20 to heroku-22
-                     - The Python version has changed from {LATEST_PYTHON_3_10} to {LATEST_PYTHON_3_11}
-                    Installing Python {LATEST_PYTHON_3_11}
-                    Installing pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
-                    
-                    [Installing dependencies using Pip]
-                    Discarding cached pip download/wheel cache
-                    Running pip install
-                    Collecting typing-extensions==4.4.0 (from -r requirements.txt (line 2))
-                      Downloading typing_extensions-4.4.0-py3-none-any.whl (26 kB)
-                    Installing collected packages: typing-extensions
-                    Successfully installed typing-extensions-4.4.0
-                    ===> EXPORTING
+                    See the log output above for more information.
                 "}
             );
-        });
-    });
+        },
+    );
 }

--- a/tests/integration/python_version.rs
+++ b/tests/integration/python_version.rs
@@ -9,12 +9,6 @@ use libcnb_test::{assert_contains, assert_empty, BuildConfig, PackResult, TestRu
 #[test]
 #[ignore = "integration test"]
 fn python_version_unspecified() {
-    let PackagingToolVersions {
-        pip_version,
-        setuptools_version,
-        wheel_version,
-    } = PackagingToolVersions::default();
-
     TestRunner::default().build(
         BuildConfig::new(builder(), "tests/fixtures/python_version_unspecified"),
         |context| {
@@ -22,23 +16,12 @@ fn python_version_unspecified() {
             assert_contains!(
                 context.pack_stdout,
                 &formatdoc! {"
-                    ===> BUILDING
-                    
                     [Determining Python version]
                     No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
                     To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
                     
                     [Installing Python and packaging tools]
                     Installing Python {DEFAULT_PYTHON_VERSION}
-                    Installing pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
-                    
-                    [Installing dependencies using Pip]
-                    Running pip install
-                    Collecting typing-extensions==4.4.0 (from -r requirements.txt (line 2))
-                      Downloading typing_extensions-4.4.0-py3-none-any.whl (26 kB)
-                    Installing collected packages: typing-extensions
-                    Successfully installed typing-extensions-4.4.0
-                    ===> EXPORTING
                 "}
             );
         },
@@ -85,6 +68,74 @@ fn python_3_11() {
     builds_with_python_version("tests/fixtures/python_3.11", LATEST_PYTHON_3_11);
 }
 
+fn builds_with_python_version(fixture_path: &str, python_version: &str) {
+    let PackagingToolVersions {
+        pip_version,
+        setuptools_version,
+        wheel_version,
+    } = PackagingToolVersions::default();
+
+    let mut config = BuildConfig::new(builder(), fixture_path);
+    // Checks that potentially broken user-provided env vars are not being passed unfiltered to
+    // subprocesses we launch (such as `pip install`), thanks to `clear-env` in `buildpack.toml`.
+    config.env("PYTHONHOME", "/invalid-path");
+
+    TestRunner::default().build(config, |context| {
+        assert_empty!(context.pack_stderr);
+        assert_contains!(
+            context.pack_stdout,
+            &formatdoc! {"
+                ===> BUILDING
+                
+                [Determining Python version]
+                Using Python version {python_version} specified in runtime.txt
+                
+                [Installing Python and packaging tools]
+                Installing Python {python_version}
+                Installing pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
+                
+                [Installing dependencies using Pip]
+                Running pip install
+                ===> EXPORTING
+            "}
+        );
+        // There's no sensible default process type we can set for Python apps.
+        assert_contains!(context.pack_stdout, "no default process type");
+
+        // Validate that the Python install works as expected at runtime.
+        let command_output = context.run_shell_command(
+            indoc! {r#"
+                set -euo pipefail
+
+                # Check that we installed the correct Python version, and that the command
+                # 'python' works (since it's a symlink to the actual 'python3' binary).
+                python --version
+
+                # Check that the Python binary is using its own 'libpython' and not the system one:
+                # https://github.com/docker-library/python/issues/784
+                # Note: This has to handle Python 3.9 and older not being built in shared library mode.
+                libpython_path=$(ldd /layers/heroku_python/python/bin/python | grep libpython || true)
+                if [[ -n "${libpython_path}" && "${libpython_path}" != *"=> /layers/"* ]]; then
+                  echo "The Python binary is not using the correct libpython!"
+                  echo "${libpython_path}"
+                  exit 1
+                fi
+
+                # Check all required dynamically linked libraries can be found in the runtime image.
+                if find /layers -name '*.so' -exec ldd '{}' + | grep 'not found'; then
+                  echo "The above dynamically linked libraries were not found!"
+                  exit 1
+                fi
+            "#}
+        );
+        assert_empty!(command_output.stderr);
+        assert_contains!(
+            command_output.stdout,
+            &format!("Python {python_version}")
+        );
+    });
+}
+
 #[test]
 #[ignore = "integration test"]
 fn runtime_txt_invalid_version() {
@@ -125,99 +176,6 @@ fn runtime_txt_non_existent_version() {
         "tests/fixtures/runtime_txt_non_existent_version",
         "999.888.777",
     );
-}
-
-fn builds_with_python_version(fixture_path: &str, python_version: &str) {
-    let PackagingToolVersions {
-        pip_version,
-        setuptools_version,
-        wheel_version,
-    } = PackagingToolVersions::default();
-
-    let mut config = BuildConfig::new(builder(), fixture_path);
-    // Checks that potentially broken user-provided env vars are not being passed unfiltered to
-    // subprocesses we launch (such as `pip install`), thanks to `clear-env` in `buildpack.toml`.
-    config.env("PYTHONHOME", "/invalid-path");
-
-    TestRunner::default().build(config, |context| {
-        assert_empty!(context.pack_stderr);
-        assert_contains!(
-            context.pack_stdout,
-            &formatdoc! {"
-                ===> BUILDING
-                
-                [Determining Python version]
-                Using Python version {python_version} specified in runtime.txt
-                
-                [Installing Python and packaging tools]
-                Installing Python {python_version}
-                Installing pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
-                
-                [Installing dependencies using Pip]
-                Running pip install
-                Collecting typing-extensions==4.4.0 (from -r requirements.txt (line 2))
-                  Downloading typing_extensions-4.4.0-py3-none-any.whl (26 kB)
-                Installing collected packages: typing-extensions
-                Successfully installed typing-extensions-4.4.0
-                ===> EXPORTING
-            "}
-        );
-        // There's no sensible default process type we can set for Python apps.
-        assert_contains!(context.pack_stdout, "no default process type");
-
-        // Validate the Python/Pip install works as expected at runtime.
-        let command_output = context.run_shell_command(
-            indoc! {r#"
-                set -euo pipefail
-
-                # Check that we installed the correct Python version, and that the command
-                # 'python' works (since it's a symlink to the actual 'python3' binary).
-                python --version
-
-                # Check that the Python binary is using its own 'libpython' and not the system one:
-                # https://github.com/docker-library/python/issues/784
-                # Note: This has to handle Python 3.9 and older not being built in shared library mode.
-                libpython_path=$(ldd /layers/heroku_python/python/bin/python | grep libpython || true)
-                if [[ -n "${libpython_path}" && "${libpython_path}" != *"=> /layers/"* ]]; then
-                  echo "The Python binary is not using the correct libpython!"
-                  echo "${libpython_path}"
-                  exit 1
-                fi
-
-                # Check all required dynamically linked libraries can be found in the runtime image.
-                if find /layers -name '*.so' -exec ldd '{}' + | grep 'not found'; then
-                  echo "The above dynamically linked libraries were not found!"
-                  exit 1
-                fi
-
-                # Check that:
-                #  - Pip is available at runtime too (and not just during the build).
-                #  - The correct versions of pip/setuptools/wheel were installed.
-                #  - Pip uses (via 'PYTHONUSERBASE') the user site-packages in the dependencies
-                #    layer, and so can find the typing-extensions package installed there.
-                #  - The "pip update available" warning is not shown (since it should be suppressed).
-                #  - The system site-packages directory is protected against running 'pip install'
-                #    without having passed '--user'.
-                pip list
-                pip install --dry-run typing-extensions
-            "#}
-        );
-        assert_empty!(command_output.stderr);
-        assert_contains!(
-            command_output.stdout,
-            &formatdoc! {"
-                Python {python_version}
-                Package           Version
-                ----------------- -------
-                pip               {pip_version}
-                setuptools        {setuptools_version}
-                typing_extensions 4.4.0
-                wheel             {wheel_version}
-                Defaulting to user installation because normal site-packages is not writeable
-                Requirement already satisfied: typing-extensions in /layers/heroku_python/dependencies/lib/"
-            }
-        );
-    });
 }
 
 fn rejects_non_existent_python_version(fixture_path: &str, python_version: &str) {


### PR DESCRIPTION
The following changes have been made to speed up the integration tests:
* The three Python/pip cache invalidation tests have been consolidated into one, since the individual variations are unit tested (and after #37 there is also one fewer codepath). The cache invalidation tests are some of the slowest given they need to run the build twice. In addition, the "stack has changed" variant was intentionally one of the ones removed, since it requires pulling an additional stack docker image per CI runner.
* Basic pip package installation is now tested as part of the existing cache re-use test, which allows the tests for every major Python version to stop installing a package (since packaging installation isn't the focus of those tests, and only slows them down).
* The pip compiled package test now uses a simpler package than `psycopg2`, making it faster to git clone and more importantly faster to compile.
* The CI workflow now only runs a subset of the tests (the stack specific tests) on older stacks. At first glance this might appear not to help the overall end to end time (given the CI run would still be waiting for the other job), however, the tests previously took longer on older stacks, since more major Python versions exist for older stacks (each of which has to be tested).

This reduces the warm local `cargo test -- --ignored` time from 1m04s to 41s, and the warm CI end to end time from ~4m05s to ~2m40s (the latest run on this PR is not quite that fast, but that's due to the current GitHub incident).

In addition:
* An explicit `docker pull` step has been added to the CI workflow, so that the time spent Docker pulling the builder image (which would otherwise happen during the first `pack build`) can be seen explicitly. (Pack will now skip pulling at all, due to `libcnb-test`'s use of `--pull-policy if-not-present`)

GUS-W-13174601.