### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.4.0] - 2023-06-07
+
 ### Changed
 
 - The default Python version is now 3.11.4 (previously 3.11.3). ([#45](https://github.com/heroku/buildpacks-python/pull/45))

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.9"
 
 [buildpack]
 id = "heroku/python"
-version = "0.3.0"
+version = "0.4.0"
 name = "Python"
 homepage = "https://github.com/heroku/buildpacks-python"
 description = "Heroku's official Python Cloud Native Buildpack."


### PR DESCRIPTION
To release:
- https://github.com/heroku/buildpacks-python/pull/45
- https://github.com/heroku/buildpacks-python/pull/43
- https://github.com/heroku/buildpacks-python/pull/37
- https://github.com/heroku/buildpacks-python/pull/35 (notably the bump in Buildpack API version)

GUS-W-13552552.