### PR TITLE
Add version links in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
@@ -39,10 +39,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The `PYTHONHOME` environment variable is now set to work around uWSGI not handling relocated Python installs correctly. ([#25](https://github.com/heroku/buildpacks-python/pull/25))
+- The `PYTHONHOME` environment variable is now set, to work around uWSGI not handling relocated Python installs correctly. ([#25](https://github.com/heroku/buildpacks-python/pull/25))
 
 ## [0.1.0] - 2023-03-06
 
 ### Added
 
 - Initial implementation. ([#3](https://github.com/heroku/buildpacks-python/pull/3))
+
+[unreleased]: https://github.com/heroku/buildpacks-python/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/heroku/buildpacks-python/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/heroku/buildpacks-python/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/heroku/buildpacks-python/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/heroku/buildpacks-python/releases/tag/v0.1.0


### PR DESCRIPTION
So that the changelog follows:
https://keepachangelog.com/en/1.1.0/

GUS-W-13794860.