### PR TITLE
Remove lifecycle output from test assertions

### DIFF
--- a/tests/integration/pip.rs
+++ b/tests/integration/pip.rs
@@ -21,8 +21,6 @@ fn pip_basic_install_and_cache_reuse() {
         assert_contains!(
             context.pack_stdout,
             &formatdoc! {"
-                ===> BUILDING
-                
                 [Determining Python version]
                 No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
                 To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
@@ -39,7 +37,6 @@ fn pip_basic_install_and_cache_reuse() {
                 Downloading typing_extensions-4.7.1-py3-none-any.whl (33 kB)
                 Installing collected packages: typing-extensions
                 Successfully installed typing-extensions-4.7.1
-                ===> EXPORTING
             "}
         );
 
@@ -73,8 +70,6 @@ fn pip_basic_install_and_cache_reuse() {
             assert_contains!(
                 rebuild_context.pack_stdout,
                 &formatdoc! {"
-                    ===> BUILDING
-                    
                     [Determining Python version]
                     No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
                     To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
@@ -92,7 +87,6 @@ fn pip_basic_install_and_cache_reuse() {
                     Using cached typing_extensions-4.7.1-py3-none-any.whl (33 kB)
                     Installing collected packages: typing-extensions
                     Successfully installed typing-extensions-4.7.1
-                    ===> EXPORTING
                 "}
             );
         });
@@ -123,8 +117,6 @@ fn pip_cache_invalidation_and_metadata_compatibility() {
                 assert_contains!(
                     rebuild_context.pack_stdout,
                     &formatdoc! {"
-                        ===> BUILDING
-                        
                         [Determining Python version]
                         No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
                         To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
@@ -147,7 +139,6 @@ fn pip_cache_invalidation_and_metadata_compatibility() {
                         Downloading typing_extensions-4.7.1-py3-none-any.whl (33 kB)
                         Installing collected packages: typing-extensions
                         Successfully installed typing-extensions-4.7.1
-                        ===> EXPORTING
                     "}
                 );
             });

--- a/tests/integration/python_version.rs
+++ b/tests/integration/python_version.rs
@@ -93,18 +93,12 @@ fn builds_with_python_version(fixture_path: &str, python_version: &str) {
         assert_contains!(
             context.pack_stdout,
             &formatdoc! {"
-                ===> BUILDING
-                
                 [Determining Python version]
                 Using Python version {python_version} specified in runtime.txt
                 
                 [Installing Python and packaging tools]
                 Installing Python {python_version}
                 Installing pip {pip_version}, setuptools {setuptools_version} and wheel {wheel_version}
-                
-                [Installing dependencies using Pip]
-                Running pip install
-                ===> EXPORTING
             "}
         );
         // There's no sensible default process type we can set for Python apps.


### PR DESCRIPTION
In lifecycle 0.30.0 the log output from lifecycle changed, which means these assertions now fail in CI, eg:
https://github.com/heroku/buildpacks-python/actions/runs/5935554908/job/16094233523?pr=96#step:9:68

These assertions were deliberately broad before, in order to ensure the test captured the full extent of the buildpack output (to prevent the tests from not being updated in case new buildpack output was added at the start/end) - knowing that there was a risk that the lifecycle output might change at some point.

Given that the new lifecycle output is dynamic (includes timestamps/durations), plus might change again soon (depending on the outcome of us reporting the logs now being overly verbose), I've decided to just remove the lifecycle output from the assertions entirely, to prevent more short term churn.

GUS-W-13998622.