### PR TITLE
Reorganise integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "python-buildpack"
 version = "0.0.0"
+publish = false
 edition = "2021"
 rust-version = "1.67"
-publish = false
+# Disable automatic integration test discovery, since we import them in main.rs (see comment there).
+autotests = false
 
 [dependencies]
 # The default `miniz_oxide` flate2 backend has poor performance in debug/under QEMU:

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,8 +133,8 @@ buildpack_main!(PythonBuildpack);
 
 // The integration tests are imported into the crate so that they can have access to private
 // APIs and constants, saving having to (a) run a dual binary/library crate, (b) expose APIs
-// publicly for things only used for testing. See:
-// https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute
+// publicly for things only used for testing. To prevent the tests from being imported twice,
+// automatic integration test discovery is disabled using `autotests = false` in Cargo.toml.
 #[cfg(test)]
-#[path = "../tests/integration/mod.rs"]
-mod integration_tests;
+#[path = "../tests/mod.rs"]
+mod tests;

--- a/tests/detect_test.rs
+++ b/tests/detect_test.rs
@@ -1,4 +1,4 @@
-use crate::integration_tests::builder;
+use crate::tests::builder;
 use indoc::indoc;
 use libcnb_test::{assert_contains, BuildConfig, PackResult, TestRunner};
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,12 +1,14 @@
 //! All integration tests are skipped by default (using the `ignore` attribute),
-//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+//! since performing builds is slow. To run them use: `cargo test -- --ignored`.
+//! These tests are not run via automatic integration test discovery, but instead are
+//! imported in main.rs so that they have access to private APIs (see comment in main.rs).
 
 use std::env;
 
-mod detect;
-mod package_manager;
-mod pip;
-mod python_version;
+mod detect_test;
+mod package_manager_test;
+mod pip_test;
+mod python_version_test;
 
 const LATEST_PYTHON_3_7: &str = "3.7.17";
 const LATEST_PYTHON_3_8: &str = "3.8.18";

--- a/tests/package_manager_test.rs
+++ b/tests/package_manager_test.rs
@@ -1,4 +1,4 @@
-use crate::integration_tests::builder;
+use crate::tests::builder;
 use indoc::indoc;
 use libcnb_test::{assert_contains, BuildConfig, PackResult, TestRunner};
 

--- a/tests/pip_test.rs
+++ b/tests/pip_test.rs
@@ -1,5 +1,5 @@
-use crate::integration_tests::{builder, DEFAULT_PYTHON_VERSION};
 use crate::packaging_tool_versions::PackagingToolVersions;
+use crate::tests::{builder, DEFAULT_PYTHON_VERSION};
 use indoc::{formatdoc, indoc};
 use libcnb_test::{
     assert_contains, assert_empty, BuildConfig, BuildpackReference, PackResult, TestRunner,

--- a/tests/python_version_test.rs
+++ b/tests/python_version_test.rs
@@ -1,8 +1,8 @@
-use crate::integration_tests::{
+use crate::packaging_tool_versions::PackagingToolVersions;
+use crate::tests::{
     builder, DEFAULT_PYTHON_VERSION, LATEST_PYTHON_3_10, LATEST_PYTHON_3_11, LATEST_PYTHON_3_7,
     LATEST_PYTHON_3_8, LATEST_PYTHON_3_9,
 };
-use crate::packaging_tool_versions::PackagingToolVersions;
 use indoc::{formatdoc, indoc};
 use libcnb_test::{assert_contains, assert_empty, BuildConfig, PackResult, TestRunner};
 


### PR DESCRIPTION
* Renames integration test filenames so that they have a `_test.rs` suffix, to prevent cases where the implementation and its test have the same filename, making it hard to distinguish between editor tabs in an IDE.
* Moves the integration tests from `tests/integration/` to `tests/` since the additional nesting was unnecessary (this also required disabling automatic integration test discovery via `autouse = false`, now that `tests/mod.rs` exists and would otherwise get imported twice).
* Renames the `integration_tests` module to `tests` so that it matches the directory name, to reduce the potential for confusion.

See:
https://doc.rust-lang.org/cargo/guide/project-layout.html
https://doc.rust-lang.org/cargo/reference/cargo-targets.html#target-auto-discovery
https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute

And for general background on testing strategies/layouts:
https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html
http://xion.io/post/code/rust-unit-test-placement.html
https://joshleeb.com/posts/rust-integration-tests.html

GUS-W-14069572.