### PR TITLE
Add a helper for running a Command with captured output

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,7 +3,7 @@ use crate::layers::python::PythonLayerError;
 use crate::package_manager::DeterminePackageManagerError;
 use crate::python_version::{PythonVersion, PythonVersionError, DEFAULT_PYTHON_VERSION};
 use crate::runtime_txt::{ParseRuntimeTxtError, RuntimeTxtError};
-use crate::utils::{CommandError, DownloadUnpackArchiveError};
+use crate::utils::{DownloadUnpackArchiveError, StreamedCommandError};
 use crate::BuildpackError;
 use indoc::{formatdoc, indoc};
 use libherokubuildpack::log::log_error;
@@ -120,12 +120,12 @@ fn on_python_version_error(error: PythonVersionError) {
 fn on_python_layer_error(error: PythonLayerError) {
     match error {
         PythonLayerError::BootstrapPipCommand(error) => match error {
-            CommandError::Io(io_error) => log_io_error(
+            StreamedCommandError::Io(io_error) => log_io_error(
                 "Unable to bootstrap pip",
                 "running the command to install pip, setuptools and wheel",
                 &io_error,
             ),
-            CommandError::NonZeroExitStatus(exit_status) => log_error(
+            StreamedCommandError::NonZeroExitStatus(exit_status) => log_error(
                 "Unable to bootstrap pip",
                 formatdoc! {"
                     The command to install pip, setuptools and wheel did not exit successfully ({exit_status}).
@@ -197,14 +197,14 @@ fn on_pip_dependencies_layer_error(error: PipDependenciesLayerError) {
             &io_error,
         ),
         PipDependenciesLayerError::PipInstallCommand(error) => match error {
-            CommandError::Io(io_error) => log_io_error(
+            StreamedCommandError::Io(io_error) => log_io_error(
                 "Unable to install dependencies using pip",
                 "running the 'pip install' command to install the application's dependencies",
                 &io_error,
             ),
             // TODO: Add more suggestions here as to causes (eg network, invalid requirements.txt,
             // package broken or not compatible with version of Python, missing system dependencies etc)
-            CommandError::NonZeroExitStatus(exit_status) => log_error(
+            StreamedCommandError::NonZeroExitStatus(exit_status) => log_error(
                 "Unable to install dependencies using pip",
                 formatdoc! {"
                     The 'pip install' command to install the application's dependencies from

--- a/src/layers/pip_dependencies.rs
+++ b/src/layers/pip_dependencies.rs
@@ -1,4 +1,4 @@
-use crate::utils::{self, CommandError};
+use crate::utils::{self, StreamedCommandError};
 use crate::{BuildpackError, PythonBuildpack};
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
@@ -66,7 +66,7 @@ impl Layer for PipDependenciesLayer<'_> {
 
         log_info("Running pip install");
 
-        utils::run_command(
+        utils::run_command_and_stream_output(
             Command::new("pip")
                 .args([
                     "install",
@@ -136,7 +136,7 @@ fn generate_layer_env(layer_path: &Path) -> LayerEnv {
 #[derive(Debug)]
 pub(crate) enum PipDependenciesLayerError {
     CreateSrcDirIo(io::Error),
-    PipInstallCommand(CommandError),
+    PipInstallCommand(StreamedCommandError),
 }
 
 impl From<PipDependenciesLayerError> for BuildpackError {

--- a/src/layers/python.rs
+++ b/src/layers/python.rs
@@ -1,6 +1,6 @@
 use crate::packaging_tool_versions::PackagingToolVersions;
 use crate::python_version::PythonVersion;
-use crate::utils::{self, CommandError, DownloadUnpackArchiveError};
+use crate::utils::{self, DownloadUnpackArchiveError, StreamedCommandError};
 use crate::{BuildpackError, PythonBuildpack};
 use libcnb::build::BuildContext;
 use libcnb::data::buildpack::StackId;
@@ -105,7 +105,7 @@ impl Layer for PythonLayer<'_> {
         let bundled_pip_module_path = bundled_pip_module_path(&python_stdlib_dir)
             .map_err(PythonLayerError::LocateBundledPipIo)?;
 
-        utils::run_command(
+        utils::run_command_and_stream_output(
             Command::new(python_binary)
                 .args([
                     &bundled_pip_module_path.to_string_lossy(),
@@ -421,7 +421,7 @@ fn bundled_pip_module_path(python_stdlib_dir: &Path) -> io::Result<PathBuf> {
 /// Errors that can occur when installing Python and required packaging tools into a layer.
 #[derive(Debug)]
 pub(crate) enum PythonLayerError {
-    BootstrapPipCommand(CommandError),
+    BootstrapPipCommand(StreamedCommandError),
     DownloadUnpackPythonArchive(DownloadUnpackArchiveError),
     LocateBundledPipIo(io::Error),
     MakeSitePackagesReadOnlyIo(io::Error),


### PR DESCRIPTION
The existing helper was for running commands with the output streamed to the user, and has been renamed to make its purpose clearer. 

The new helper captures the output instead. It is currently unused, but is needed for the upcoming Django collectstatic support PR.

GUS-W-14073493.