### PR TITLE
Set the working directory explicitly when starting subprocesses

### DIFF
--- a/src/layers/pip_dependencies.rs
+++ b/src/layers/pip_dependencies.rs
@@ -47,7 +47,7 @@ impl Layer for PipDependenciesLayer<'_> {
 
     fn create(
         &self,
-        _context: &BuildContext<Self::Buildpack>,
+        context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
         let layer_env = generate_layer_env(layer_path);
@@ -98,6 +98,7 @@ impl Layer for PipDependenciesLayer<'_> {
                     "--src",
                     &src_dir.to_string_lossy(),
                 ])
+                .current_dir(&context.app_dir)
                 .env_clear()
                 .envs(&command_env),
         )

--- a/src/layers/python.rs
+++ b/src/layers/python.rs
@@ -118,6 +118,7 @@ impl Layer for PythonLayer<'_> {
                     format!("setuptools=={setuptools_version}").as_str(),
                     format!("wheel=={wheel_version}").as_str(),
                 ])
+                .current_dir(&context.app_dir)
                 .env_clear()
                 .envs(&command_env),
         )


### PR DESCRIPTION
Whilst the CNB spec [says](https://github.com/buildpacks/spec/blob/main/buildpack.md#build) that during the build the working directory is guaranteed to be the app source directory, it's still clearer to those reading the code if we set the working directory to the app directory explicitly when working with `Command`.

GUS-W-14076517.