### PR TITLE
Refactor error handling

### DIFF
--- a/src/layers/pip_dependencies.rs
+++ b/src/layers/pip_dependencies.rs
@@ -62,7 +62,7 @@ impl Layer for PipDependenciesLayer<'_> {
         // in the dependencies layer instead for consistency. (Plus if the dependencies layer were
         // ever cached, storing the repository in the app dir would break on repeat-builds).
         let src_dir = layer_path.join("src");
-        fs::create_dir(&src_dir).map_err(PipDependenciesLayerError::CreateSrcDirIo)?;
+        fs::create_dir(&src_dir).map_err(PipDependenciesLayerError::CreateSrcDir)?;
 
         log_info("Running pip install");
 
@@ -136,7 +136,7 @@ fn generate_layer_env(layer_path: &Path) -> LayerEnv {
 /// Errors that can occur when installing the project's dependencies into a layer using Pip.
 #[derive(Debug)]
 pub(crate) enum PipDependenciesLayerError {
-    CreateSrcDirIo(io::Error),
+    CreateSrcDir(io::Error),
     PipInstallCommand(StreamedCommandError),
 }
 

--- a/src/layers/python.rs
+++ b/src/layers/python.rs
@@ -103,7 +103,7 @@ impl Layer for PythonLayer<'_> {
         // Python bundles Pip within its standard library, which we can use to install our chosen
         // pip version from PyPI, saving us from having to download the usual pip bootstrap script.
         let bundled_pip_module_path = bundled_pip_module_path(&python_stdlib_dir)
-            .map_err(PythonLayerError::LocateBundledPipIo)?;
+            .map_err(PythonLayerError::LocateBundledPip)?;
 
         utils::run_command_and_stream_output(
             Command::new(python_binary)
@@ -132,7 +132,7 @@ impl Layer for PythonLayer<'_> {
         // user installs in such cases:
         // https://github.com/pypa/pip/blob/23.0/src/pip/_internal/commands/install.py#L715-L773
         fs::set_permissions(site_packages_dir, Permissions::from_mode(0o555))
-            .map_err(PythonLayerError::MakeSitePackagesReadOnlyIo)?;
+            .map_err(PythonLayerError::MakeSitePackagesReadOnly)?;
 
         let layer_metadata = self.generate_layer_metadata(&context.stack_id);
         LayerResultBuilder::new(layer_metadata)
@@ -424,8 +424,8 @@ fn bundled_pip_module_path(python_stdlib_dir: &Path) -> io::Result<PathBuf> {
 pub(crate) enum PythonLayerError {
     BootstrapPipCommand(StreamedCommandError),
     DownloadUnpackPythonArchive(DownloadUnpackArchiveError),
-    LocateBundledPipIo(io::Error),
-    MakeSitePackagesReadOnlyIo(io::Error),
+    LocateBundledPip(io::Error),
+    MakeSitePackagesReadOnly(io::Error),
     PythonArchiveNotFound {
         python_version: PythonVersion,
         stack: StackId,

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ impl Buildpack for PythonBuildpack {
         // but we first need a better understanding of real-world use-cases, so that we can work
         // out how best to support them without sacrificing existing error handling UX (such as
         // wanting to show a clear error when requirements.txt is missing).
-        if utils::is_python_project(&context.app_dir).map_err(BuildpackError::DetectIo)? {
+        if utils::is_python_project(&context.app_dir).map_err(BuildpackError::BuildpackDetection)? {
             DetectResultBuilder::pass().build()
         } else {
             log_info("No Python project files found (such as requirements.txt).");
@@ -123,7 +123,7 @@ impl Buildpack for PythonBuildpack {
 #[derive(Debug)]
 pub(crate) enum BuildpackError {
     /// IO errors when performing buildpack detection.
-    DetectIo(io::Error),
+    BuildpackDetection(io::Error),
     /// Errors determining which Python package manager to use for a project.
     DeterminePackageManager(DeterminePackageManagerError),
     /// Errors running the Django collectstatic command.

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -23,7 +23,7 @@ pub(crate) fn determine_package_manager(
         if app_dir
             .join(filename)
             .try_exists()
-            .map_err(DeterminePackageManagerError::Io)?
+            .map_err(DeterminePackageManagerError::CheckFileExists)?
         {
             return Ok(package_manager);
         }
@@ -35,7 +35,7 @@ pub(crate) fn determine_package_manager(
 /// Errors that can occur when determining which Python package manager to use for a project.
 #[derive(Debug)]
 pub(crate) enum DeterminePackageManagerError {
-    Io(io::Error),
+    CheckFileExists(io::Error),
     NoneFound,
 }
 

--- a/src/runtime_txt.rs
+++ b/src/runtime_txt.rs
@@ -12,7 +12,7 @@ pub(crate) fn read_version(app_dir: &Path) -> Result<Option<PythonVersion>, Runt
     let runtime_txt_path = app_dir.join("runtime.txt");
 
     utils::read_optional_file(&runtime_txt_path)
-        .map_err(RuntimeTxtError::Io)?
+        .map_err(RuntimeTxtError::Read)?
         .map(|contents| parse(&contents).map_err(RuntimeTxtError::Parse))
         .transpose()
 }
@@ -52,8 +52,8 @@ fn parse(contents: &str) -> Result<PythonVersion, ParseRuntimeTxtError> {
 /// Errors that can occur when reading and parsing a `runtime.txt` file.
 #[derive(Debug)]
 pub(crate) enum RuntimeTxtError {
-    Io(io::Error),
     Parse(ParseRuntimeTxtError),
+    Read(io::Error),
 }
 
 /// Errors that can occur when parsing the contents of a `runtime.txt` file.
@@ -216,7 +216,7 @@ mod tests {
     fn read_version_io_error() {
         assert!(matches!(
             read_version(Path::new("tests/fixtures/empty/.gitkeep")).unwrap_err(),
-            RuntimeTxtError::Io(_)
+            RuntimeTxtError::Read(_)
         ));
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,14 +60,14 @@ pub(crate) fn download_and_unpack_gzipped_archive(
     let gzip_decoder = GzDecoder::new(response.into_reader());
     Archive::new(gzip_decoder)
         .unpack(destination)
-        .map_err(DownloadUnpackArchiveError::Io)
+        .map_err(DownloadUnpackArchiveError::Unpack)
 }
 
 /// Errors that can occur when downloading and unpacking an archive using `download_and_unpack_gzipped_archive`.
 #[derive(Debug)]
 pub(crate) enum DownloadUnpackArchiveError {
-    Io(io::Error),
     Request(ureq::Error),
+    Unpack(io::Error),
 }
 
 /// A helper for running an external process using [`Command`], that streams stdout/stderr
@@ -89,7 +89,6 @@ pub(crate) fn run_command_and_stream_output(
 
 /// A helper for running an external process using [`Command`], that captures stdout/stderr
 /// and checks that the exit status of the process was non-zero.
-#[allow(dead_code)]
 pub(crate) fn run_command_and_capture_output(
     command: &mut Command,
 ) -> Result<Output, CapturedCommandError> {


### PR DESCRIPTION
* Improve error enum naming
* Move all logging out of the top level `on_buildpack_error`
* Remove redundant Clippy `allow`

GUS-W-14116059.