### PR TITLE
Switch tests from `heroku/buildpacks:20` to `heroku/builder:20`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["builder:22", "buildpacks:20"]
+        builder: ["builder:22", "builder:20"]
     env:
       INTEGRATION_TEST_CNB_BUILDER: heroku/${{ matrix.builder }}
     steps:

--- a/tests/python_version_test.rs
+++ b/tests/python_version_test.rs
@@ -34,7 +34,7 @@ fn python_3_7() {
     // Python 3.7 is only available on Heroku-20 and older.
     let fixture = "tests/fixtures/python_3.7";
     match builder().as_str() {
-        "heroku/buildpacks:20" => builds_with_python_version(fixture, LATEST_PYTHON_3_7),
+        "heroku/builder:20" => builds_with_python_version(fixture, LATEST_PYTHON_3_7),
         _ => rejects_non_existent_python_version(fixture, LATEST_PYTHON_3_7),
     };
 }
@@ -45,7 +45,7 @@ fn python_3_8() {
     // Python 3.8 is only available on Heroku-20 and older.
     let fixture = "tests/fixtures/python_3.8";
     match builder().as_str() {
-        "heroku/buildpacks:20" => builds_with_python_version(fixture, LATEST_PYTHON_3_8),
+        "heroku/builder:20" => builds_with_python_version(fixture, LATEST_PYTHON_3_8),
         _ => rejects_non_existent_python_version(fixture, LATEST_PYTHON_3_8),
     };
 }
@@ -187,7 +187,7 @@ fn rejects_non_existent_python_version(fixture_path: &str, python_version: &str)
         BuildConfig::new(&builder, fixture_path).expected_pack_result(PackResult::Failure),
         |context| {
             let expected_stack = match builder.as_str() {
-                "heroku/buildpacks:20" => "heroku-20",
+                "heroku/builder:20" => "heroku-20",
                 "heroku/builder:22" => "heroku-22",
                 _ => unimplemented!("Unknown builder!"),
             };


### PR DESCRIPTION
Since the `heroku/buildpacks:20` image is about to be deprecated, and has been replaced by the newly added `heroku/builder:20` for those that need to use a Heroku-20 based builder.

The build and run images used by `heroku/builder:20` are the same as those used by `heroku/buildpacks:20` - the only differences between the builders are the included buildpacks (which is somewhat irrelevant for these integration tests, since the buildpack under test will be injected instead).

The smoke tests in the `heroku/builder` GitHub repo are still testing against all image variants (until such time as we make the legacy images error with an EOL message), so we still have test coverage against them.

See:
https://github.com/heroku/builder/pull/394
https://salesforce.quip.com/0JtbAYiWZYk6

GUS-W-14186015.