### PR TITLE
Fix Heroku-20 integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,4 +71,4 @@ jobs:
         run: cargo test --locked -- --ignored --test-threads 5
       - name: Run integration tests (stack-specific tests only)
         if: matrix.builder != 'builder:22'
-        run: cargo test --locked -- --ignored --test-threads 5 'python_version::'
+        run: cargo test --locked -- --ignored --test-threads 5 'python_version_test::'


### PR DESCRIPTION
These tests had stopped running as of the module rename in #105, since `cargo test` silently ignores invalid test names, ref: https://github.com/rust-lang/cargo/issues/11875

I'm going to be changing the way tests are split up in CI soon, which will also make this less fragile - so for now I'm just fixing the module name to restore test coverage on Heroku-20.

GUS-W-14346746.