### PR TITLE
Update buildpack metadata in buildpack.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated pip from 23.2.1 to 23.3.1. ([#131](https://github.com/heroku/buildpacks-python/pull/131))
 - Updated wheel from 0.41.0 to 0.41.2. ([#100](https://github.com/heroku/buildpacks-python/pull/100))
+- Updated buildpack display name and description. ([#135](https://github.com/heroku/buildpack-python/pull/135))
 
 ## [0.7.1] - 2023-10-02
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,9 +3,9 @@ api = "0.9"
 [buildpack]
 id = "heroku/python"
 version = "0.7.1"
-name = "Python"
+name = "Heroku Python"
 homepage = "https://github.com/heroku/buildpacks-python"
-description = "Heroku's official Python Cloud Native Buildpack."
+description = "Heroku's buildpack for Python applications."
 keywords = ["python", "heroku"]
 
 [[buildpack.licenses]]


### PR DESCRIPTION
Adjusts the buildpack `name` and `description` in `buildpack.toml` to match the style discussed in:
https://github.com/heroku/cnb-builder-images/issues/408

These fields are used by the CNB registry and can also be seen in the output of `pack builder inspect`. They are not used by `pack build` or Kodon.

GUS-W-14121598.