### PR TITLE
Switch to Cargo.toml based lint configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,19 @@ name = "python-buildpack"
 version = "0.0.0"
 publish = false
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.74"
 # Disable automatic integration test discovery, since we import them in main.rs (see comment there).
 autotests = false
+
+[lints.rust]
+unused_crate_dependencies = "warn"
+
+[lints.clippy]
+pedantic = "warn"
+# Prevent warnings caused by the large size of `ureq::Error` in error enums,
+# where it is not worth boxing since the enum size doesn't affect performance.
+large_enum_variant = "allow"
+result_large_err = "allow"
 
 [dependencies]
 # The default `miniz_oxide` flate2 backend has poor performance in debug/under QEMU:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,3 @@
-#![warn(clippy::pedantic)]
-#![warn(unused_crate_dependencies)]
-// Prevent warnings caused by the large size of `ureq::Error` in error enums,
-// where it is not worth boxing since the enum size doesn't affect performance.
-#![allow(clippy::large_enum_variant)]
-#![allow(clippy::result_large_err)]
-
 mod django;
 mod errors;
 mod layers;


### PR DESCRIPTION
As of the Cargo included in Rust 1.74, lints can now be configured in `Cargo.toml` across whole crates/workspaces:
https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html
https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section

This reduces the boilerplate, and chance that we forget to enable lints in some targets.

Since this feature requires Rust 1.74, the MSRV has also been bumped (however, libcnb 0.16.0 already requires Rust 1.74, so in practice this is a no-op).

GUS-W-14523753.