### PR TITLE
Enable additional rustc and Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,14 @@ rust-version = "1.74"
 autotests = false
 
 [lints.rust]
+unreachable_pub = "warn"
+unsafe_code = "warn"
 unused_crate_dependencies = "warn"
 
 [lints.clippy]
+panic_in_result_fn = "warn"
 pedantic = "warn"
+unwrap_used = "warn"
 # Prevent warnings caused by the large size of `ureq::Error` in error enums,
 # where it is not worth boxing since the enum size doesn't affect performance.
 large_enum_variant = "allow"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/src/layers/pip_cache.rs
+++ b/src/layers/pip_cache.rs
@@ -13,9 +13,9 @@ use std::path::Path;
 /// Layer containing Pip's cache of HTTP requests/downloads and built package wheels.
 pub(crate) struct PipCacheLayer<'a> {
     /// The Python version used for this build.
-    pub python_version: &'a PythonVersion,
+    pub(crate) python_version: &'a PythonVersion,
     /// The pip, setuptools and wheel versions used for this build.
-    pub packaging_tool_versions: &'a PackagingToolVersions,
+    pub(crate) packaging_tool_versions: &'a PackagingToolVersions,
 }
 
 impl Layer for PipCacheLayer<'_> {

--- a/src/layers/pip_dependencies.rs
+++ b/src/layers/pip_dependencies.rs
@@ -14,9 +14,9 @@ use std::{fs, io};
 /// Layer containing the application's Python dependencies, installed using Pip.
 pub(crate) struct PipDependenciesLayer<'a> {
     /// Environment variables inherited from earlier buildpack steps.
-    pub command_env: &'a Env,
+    pub(crate) command_env: &'a Env,
     /// The path to the Pip cache directory, which is stored in another layer since it isn't needed at runtime.
-    pub pip_cache_dir: PathBuf,
+    pub(crate) pip_cache_dir: PathBuf,
 }
 
 impl Layer for PipDependenciesLayer<'_> {

--- a/src/layers/python.rs
+++ b/src/layers/python.rs
@@ -32,11 +32,11 @@ use std::{fs, io};
 ///  - It matches what both local and official Docker image environments do.
 pub(crate) struct PythonLayer<'a> {
     /// Environment variables inherited from earlier buildpack steps.
-    pub command_env: &'a Env,
+    pub(crate) command_env: &'a Env,
     /// The Python version that this layer should install.
-    pub python_version: &'a PythonVersion,
+    pub(crate) python_version: &'a PythonVersion,
     /// The pip, setuptools and wheel versions that this layer should install.
-    pub packaging_tool_versions: &'a PackagingToolVersions,
+    pub(crate) packaging_tool_versions: &'a PackagingToolVersions,
 }
 
 impl Layer for PythonLayer<'_> {

--- a/src/packaging_tool_versions.rs
+++ b/src/packaging_tool_versions.rs
@@ -10,9 +10,9 @@ const WHEEL_REQUIREMENT: &str = include_str!("../requirements/wheel.txt");
 /// semver, and we never introspect the version parts anyway.
 #[derive(Clone, Deserialize, PartialEq, Serialize)]
 pub(crate) struct PackagingToolVersions {
-    pub pip_version: String,
-    pub setuptools_version: String,
-    pub wheel_version: String,
+    pub(crate) pip_version: String,
+    pub(crate) setuptools_version: String,
+    pub(crate) wheel_version: String,
 }
 
 impl Default for PackagingToolVersions {

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -15,13 +15,13 @@ pub(crate) const DEFAULT_PYTHON_VERSION: PythonVersion = PythonVersion {
 /// Representation of a specific Python `X.Y.Z` version.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct PythonVersion {
-    pub major: u16,
-    pub minor: u16,
-    pub patch: u16,
+    pub(crate) major: u16,
+    pub(crate) minor: u16,
+    pub(crate) patch: u16,
 }
 
 impl PythonVersion {
-    pub fn new(major: u16, minor: u16, patch: u16) -> Self {
+    pub(crate) fn new(major: u16, minor: u16, patch: u16) -> Self {
         Self {
             major,
             minor,
@@ -29,7 +29,7 @@ impl PythonVersion {
         }
     }
 
-    pub fn url(&self, stack_id: &StackId) -> String {
+    pub(crate) fn url(&self, stack_id: &StackId) -> String {
         // TODO: (W-11474658) Switch to tracking versions/URLs via a manifest file.
         format!(
             "https://heroku-buildpack-python.s3.us-east-1.amazonaws.com/{}/runtimes/python-{}.{}.{}.tar.gz",

--- a/src/runtime_txt.rs
+++ b/src/runtime_txt.rs
@@ -59,7 +59,7 @@ pub(crate) enum RuntimeTxtError {
 /// Errors that can occur when parsing the contents of a `runtime.txt` file.
 #[derive(Debug, PartialEq)]
 pub(crate) struct ParseRuntimeTxtError {
-    pub cleaned_contents: String,
+    pub(crate) cleaned_contents: String,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Enables some off-by-default lints that we already use in the `libcnb.rs` repository.

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unreachable-pub
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-code
https://rust-lang.github.io/rust-clippy/master/index.html#/panic_in_result_fn
https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_used

GUS-W-14523753.