### PR TITLE
Use Python 3.12 as the default Python version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed the default Python version from 3.11 to 3.12. ([#152](https://github.com/heroku/buildpacks-python/pull/152))
 - Updated wheel from 0.41.3 to 0.42.0. ([#150](https://github.com/heroku/buildpacks-python/pull/150))
 
 ## [0.7.3] - 2023-11-06

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 /// The Python version that will be installed if the project does not specify an explicit version.
 pub(crate) const DEFAULT_PYTHON_VERSION: PythonVersion = PythonVersion {
     major: 3,
-    minor: 11,
-    patch: 6,
+    minor: 12,
+    patch: 0,
 };
 
 /// Representation of a specific Python `X.Y.Z` version.

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -17,7 +17,7 @@ const LATEST_PYTHON_3_9: &str = "3.9.18";
 const LATEST_PYTHON_3_10: &str = "3.10.13";
 const LATEST_PYTHON_3_11: &str = "3.11.6";
 const LATEST_PYTHON_3_12: &str = "3.12.0";
-const DEFAULT_PYTHON_VERSION: &str = LATEST_PYTHON_3_11;
+const DEFAULT_PYTHON_VERSION: &str = LATEST_PYTHON_3_12;
 
 const DEFAULT_BUILDER: &str = "heroku/builder:22";
 


### PR DESCRIPTION
Previously if an app did not specify a Python version via a `runtime.txt` file, then the buildpack would default to the latest Python 3.11 release.

Now the buildpack will use the latest Python 3.12 release.

Use-cases involving new apps that aren't compatible with Python 3.12 will now need to specify Python 3.11 explicitly.

However most apps should be compatible, since Python 3.12 was released a couple of months ago (2023-10-02), does not contain significant breaking changes over Python 3.11, and has been happily used by the python-getting-started project since 2023-10-04.

Note: For the Python CNB, this change also affects existing apps, since the CNB no longer uses the "stick versions" approach used by the classic Python buildpack.

See:
https://docs.python.org/3.12/whatsnew/3.12.html
https://github.com/heroku/heroku-buildpack-python/pull/1516

GUS-W-14217496.