### PR TITLE
Fix lint errors with Rust 1.78 beta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "python-buildpack"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.77"
 # Disable automatic integration test discovery, since we import them in main.rs (see comment there).
 autotests = false
 
@@ -12,7 +12,8 @@ unused_crate_dependencies = "warn"
 
 [lints.clippy]
 panic_in_result_fn = "warn"
-pedantic = "warn"
+# The explicit priority is required due to https://github.com/rust-lang/cargo/issues/13565.
+pedantic = { level = "warn", priority = -1 }
 unwrap_used = "warn"
 # Prevent warnings caused by the large size of `ureq::Error` in error enums,
 # where it is not worth boxing since the enum size doesn't affect performance.


### PR DESCRIPTION
Fixes this lint error I get locally with Rust 1.78 beta:

```
error: lint group `pedantic` has the same priority (0) as a lint
  --> Cargo.toml:15:1
   |
15 | pedantic = "warn"
   | ^^^^^^^^   ------ has an implicit priority of 0
16 | unwrap_used = "warn"
   | ----------- has the same priority as this lint
   |
   = note: the order of the lints in the table is ignored by Cargo
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#lint_groups_priority
   = note: `#[deny(clippy::lint_groups_priority)]` on by default
help: to have lints override the group set `pedantic` to a lower priority
   |
15 | pedantic = { level = "warn", priority = -1 }
   |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

See:
https://rust-lang.github.io/rust-clippy/master/index.html#/lint_groups_priority
https://github.com/rust-lang/rust-clippy/pull/11832
https://github.com/rust-lang/cargo/issues/12918
https://github.com/rust-lang/cargo/issues/13565

GUS-W-15303120.