### PR TITLE
Remove `[[stacks]]` table workaround from `buildpack.toml`

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -11,11 +11,6 @@ keywords = ["python", "heroku"]
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-# This workaround can be removed once a new Pack release ships that includes:
-# https://github.com/buildpacks/pack/pull/2081
-[[stacks]]
-id = "*"
-
 [[targets]]
 os = "linux"
 arch = "amd64"


### PR DESCRIPTION
Since we're now using a Pack CLI version in our CNB release automation that contains the fix for:
https://github.com/buildpacks/pack/issues/2047