### PR TITLE
Add more filetypes to the list recognised by buildpack detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack detection now recognises more types of Python-related files. ([#215](https://github.com/heroku/buildpacks-python/pull/215))
+
 ## [0.11.0] - 2024-06-07
 
 ### Changed

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -7,16 +7,21 @@ use std::path::Path;
 /// This list is deliberately larger than just the list of supported package manager files,
 /// so that Python projects that are missing some of the required files still pass detection,
 /// allowing us to show a helpful error message during the build phase.
-const KNOWN_PYTHON_PROJECT_FILES: [&str; 9] = [
+const KNOWN_PYTHON_PROJECT_FILES: [&str; 14] = [
     ".python-version",
+    "app.py",
     "main.py",
     "manage.py",
+    "pdm.lock",
     "Pipfile",
+    "Pipfile.lock",
     "poetry.lock",
     "pyproject.toml",
     "requirements.txt",
     "runtime.txt",
+    "setup.cfg",
     "setup.py",
+    "uv.lock",
 ];
 
 /// Returns whether the specified project directory is that of a Python project, and so


### PR DESCRIPTION
This buildpack's detection logic is intentionally lenient about what files are required in order to pass detection - so that projects missing required files (such as `requirements.txt`) correctly get marked as being a Python app. Stricter validation then occurs later during the build phase, as part of deciding which package manager to use.

This change adds the following to the known Python files list:
- `app.py` - filename that's autodetected by the Flask CLI and used in Flask docs/examples
- `pdm.lock` - the lockfile for https://pdm-project.org
- `Pipfile.lock` - Pipenv's lockfile (whilst `Pipfile` was already in the known files list, it makes sense to have the lockfile there too for completeness)
- `setup.cfg` - configuration file used with setuptools (as a successor to `setup.py` and predecessor of `pyproject.toml`) and also used as the config location for a number of Python tools such as linters (whilst it's mostly been replaced by `pyproject.toml`, quite a few projects will still be using the old file)
- `uv.lock` - the lockfile for https://github.com/astral-sh/uv

This means that for any project that is:
- missing its `requirements.txt`
- doesn't have one of the files on the existing known files list
- has one of the above new files

...then detection will now pass (when it would have failed before) and the build will proceed to the build phase, where this clearer error message will be shown:
https://github.com/heroku/buildpacks-python/blob/ae439b223afc7fa1160ee38b687ce4ad77a798d6/src/errors.rs#L70-L82

I've not added any new tests since this codepath is well tested, and it's pointless to have a test for every entry in the `KNOWN_PYTHON_PROJECT_FILES` constant. See:
https://github.com/heroku/buildpacks-python/blob/ae439b223afc7fa1160ee38b687ce4ad77a798d6/src/detect.rs#L42-L46
https://github.com/heroku/buildpacks-python/blob/ae439b223afc7fa1160ee38b687ce4ad77a798d6/tests/package_manager_test.rs#L5-L28