### PR TITLE
Stop manually creating a `src` dir in the Pip dependencies layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Stopped manually creating a `src` directory inside the Pip dependencies layer. Pip will create the directory itself if needed (when there are editable VCS dependencies). ([#228](https://github.com/heroku/buildpacks-python/pull/228))
+
 ## [0.12.1] - 2024-07-15
 
 ### Changed

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -196,11 +196,6 @@ fn on_python_layer_error(error: PythonLayerError) {
 
 fn on_pip_dependencies_layer_error(error: PipDependenciesLayerError) {
     match error {
-        PipDependenciesLayerError::CreateSrcDir(io_error) => log_io_error(
-            "Unable to create 'src' directory required for pip install",
-            "creating the 'src' directory in the pip layer, prior to running pip install",
-            &io_error,
-        ),
         PipDependenciesLayerError::PipInstallCommand(error) => match error {
             StreamedCommandError::Io(io_error) => log_io_error(
                 "Unable to install dependencies using pip",


### PR DESCRIPTION
Since Pip will create the directory itself if needed (which is only when there are editable mode VCS dependencies being installed).

This behaviour is already tested, via:
https://github.com/heroku/buildpacks-python/blob/ff51b31c65cbd1932fc4cdc585c60942efcfe836/tests/pip_test.rs#L197-L216