### PR TITLE
Improve tests for buildpack env var handling

### DIFF
--- a/src/layers/pip_dependencies.rs
+++ b/src/layers/pip_dependencies.rs
@@ -151,15 +151,15 @@ mod tests {
         let mut base_env = Env::new();
         base_env.insert("PYTHONUSERBASE", "this-should-be-overridden");
 
-        let layer_env = generate_layer_env(Path::new("/layers/dependencies"));
+        let layer_env = generate_layer_env(Path::new("/layer-dir"));
 
         assert_eq!(
             utils::environment_as_sorted_vector(&layer_env.apply(Scope::Build, &base_env)),
-            [("PYTHONUSERBASE", "/layers/dependencies")]
+            [("PYTHONUSERBASE", "/layer-dir")]
         );
         assert_eq!(
             utils::environment_as_sorted_vector(&layer_env.apply(Scope::Launch, &base_env)),
-            [("PYTHONUSERBASE", "/layers/dependencies")]
+            [("PYTHONUSERBASE", "/layer-dir")]
         );
     }
 }

--- a/src/layers/python.rs
+++ b/src/layers/python.rs
@@ -562,43 +562,6 @@ mod tests {
 
     #[test]
     fn python_layer_env() {
-        let layer_env = generate_layer_env(
-            Path::new("/layers/python"),
-            &PythonVersion {
-                major: 3,
-                minor: 9,
-                patch: 0,
-            },
-        );
-
-        // Remember to force invalidation of the cached layer if these env vars ever change.
-        assert_eq!(
-            utils::environment_as_sorted_vector(&layer_env.apply_to_empty(Scope::Build)),
-            [
-                ("CPATH", "/layers/python/include/python3.9"),
-                ("LANG", "C.UTF-8"),
-                ("PIP_DISABLE_PIP_VERSION_CHECK", "1"),
-                ("PKG_CONFIG_PATH", "/layers/python/lib/pkgconfig"),
-                ("PYTHONHOME", "/layers/python"),
-                ("PYTHONUNBUFFERED", "1"),
-                ("SOURCE_DATE_EPOCH", "315532801"),
-            ]
-        );
-        assert_eq!(
-            utils::environment_as_sorted_vector(&layer_env.apply_to_empty(Scope::Launch)),
-            [
-                ("CPATH", "/layers/python/include/python3.9"),
-                ("LANG", "C.UTF-8"),
-                ("PIP_DISABLE_PIP_VERSION_CHECK", "1"),
-                ("PKG_CONFIG_PATH", "/layers/python/lib/pkgconfig"),
-                ("PYTHONHOME", "/layers/python"),
-                ("PYTHONUNBUFFERED", "1"),
-            ]
-        );
-    }
-
-    #[test]
-    fn python_layer_env_with_existing_env() {
         let mut base_env = Env::new();
         base_env.insert("CPATH", "/base");
         base_env.insert("LANG", "this-should-be-overridden");
@@ -606,10 +569,9 @@ mod tests {
         base_env.insert("PKG_CONFIG_PATH", "/base");
         base_env.insert("PYTHONHOME", "this-should-be-overridden");
         base_env.insert("PYTHONUNBUFFERED", "this-should-be-overridden");
-        base_env.insert("SOURCE_DATE_EPOCH", "this-should-be-preserved");
 
         let layer_env = generate_layer_env(
-            Path::new("/layers/python"),
+            Path::new("/layer-dir"),
             &PythonVersion {
                 major: 3,
                 minor: 11,
@@ -621,25 +583,24 @@ mod tests {
         assert_eq!(
             utils::environment_as_sorted_vector(&layer_env.apply(Scope::Build, &base_env)),
             [
-                ("CPATH", "/layers/python/include/python3.11:/base"),
+                ("CPATH", "/layer-dir/include/python3.11:/base"),
                 ("LANG", "C.UTF-8"),
                 ("PIP_DISABLE_PIP_VERSION_CHECK", "1"),
-                ("PKG_CONFIG_PATH", "/layers/python/lib/pkgconfig:/base"),
-                ("PYTHONHOME", "/layers/python"),
+                ("PKG_CONFIG_PATH", "/layer-dir/lib/pkgconfig:/base"),
+                ("PYTHONHOME", "/layer-dir"),
                 ("PYTHONUNBUFFERED", "1"),
-                ("SOURCE_DATE_EPOCH", "this-should-be-preserved"),
+                ("SOURCE_DATE_EPOCH", "315532801"),
             ]
         );
         assert_eq!(
             utils::environment_as_sorted_vector(&layer_env.apply(Scope::Launch, &base_env)),
             [
-                ("CPATH", "/layers/python/include/python3.11:/base"),
+                ("CPATH", "/layer-dir/include/python3.11:/base"),
                 ("LANG", "C.UTF-8"),
                 ("PIP_DISABLE_PIP_VERSION_CHECK", "1"),
-                ("PKG_CONFIG_PATH", "/layers/python/lib/pkgconfig:/base"),
-                ("PYTHONHOME", "/layers/python"),
+                ("PKG_CONFIG_PATH", "/layer-dir/lib/pkgconfig:/base"),
+                ("PYTHONHOME", "/layer-dir"),
                 ("PYTHONUNBUFFERED", "1"),
-                ("SOURCE_DATE_EPOCH", "this-should-be-preserved"),
             ]
         );
     }

--- a/tests/python_version_test.rs
+++ b/tests/python_version_test.rs
@@ -84,20 +84,7 @@ fn builds_with_python_version(fixture_path: &str, python_version: &str) {
         wheel_version,
     } = PackagingToolVersions::default();
 
-    let mut config = default_build_config(fixture_path);
-    // Checks that potentially broken user-provided env vars don't take precedence over those
-    // set by this buildpack and break running Python. These are based on the env vars that
-    // used to be set by `bin/release` by very old versions of the classic Python buildpack:
-    // https://github.com/heroku/heroku-buildpack-python/blob/27abdfe7d7ad104dabceb45641415251e965671c/bin/release#L11-L18
-    config.envs([
-        ("LD_LIBRARY_PATH", "/invalid-path"),
-        ("LIBRARY_PATH", "/invalid-path"),
-        ("PATH", "/invalid-path"),
-        ("PYTHONHOME", "/invalid-path"),
-        ("PYTHONPATH", "/invalid-path"),
-    ]);
-
-    TestRunner::default().build(config, |context| {
+    TestRunner::default().build(default_build_config(fixture_path), |context| {
         assert_empty!(context.pack_stderr);
         assert_contains!(
             context.pack_stdout,
@@ -113,7 +100,7 @@ fn builds_with_python_version(fixture_path: &str, python_version: &str) {
         // There's no sensible default process type we can set for Python apps.
         assert_contains!(context.pack_stdout, "no default process type");
 
-        // Validate that the Python install works as expected at runtime.
+        // Validate that the Python install works as expected at run-time.
         let command_output = context.run_shell_command(
             indoc! {r#"
                 set -euo pipefail


### PR DESCRIPTION
* Shifts the testing of buildpack env vars handling slightly more towards integration tests rather than unit tests, since a big part of env var handling is ensuring the env is passed around correctly + aspects like the automatic env vars added by libcnb and lifecycle, which can only be properly tested via integration tests.
* Adds more testing of broken user-provided env vars, by passing them in by default for all tests (instead of a single test), and by adding more broken env vars to the list.
* In the unit tests, switches the example layer location to one that's more obviously an example path, to prevent anyone reading the tests from thinking that's the actual location set by the buildpack.

This change will help validate the env var handling remains consistent with the upcoming transition to libcnb.rs' struct layer API.

GUS-W-16261336.