### PR TITLE
Stop setting `CPATH` and `PKG_CONFIG_PATH` at launch time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Stopped manually creating a `src` directory inside the Pip dependencies layer. Pip will create the directory itself if needed (when there are editable VCS dependencies). ([#228](https://github.com/heroku/buildpacks-python/pull/228))
+- Stopped setting `CPATH` and `PKG_CONFIG_PATH` at launch time. ([#231](https://github.com/heroku/buildpacks-python/pull/231))
 
 ## [0.12.1] - 2024-07-15
 

--- a/tests/pip_test.rs
+++ b/tests/pip_test.rs
@@ -59,12 +59,10 @@ fn pip_basic_install_and_cache_reuse() {
         assert_contains!(
             command_output.stdout,
             &formatdoc! {"
-                CPATH=/layers/heroku_python/python/include/python3.12
                 LANG=C.UTF-8
                 LD_LIBRARY_PATH=/layers/heroku_python/python/lib:/layers/heroku_python/dependencies/lib
                 PATH=/layers/heroku_python/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
                 PIP_DISABLE_PIP_VERSION_CHECK=1
-                PKG_CONFIG_PATH=/layers/heroku_python/python/lib/pkgconfig
                 PYTHONHOME=/layers/heroku_python/python
                 PYTHONUNBUFFERED=1
                 PYTHONUSERBASE=/layers/heroku_python/dependencies


### PR DESCRIPTION
For parity with the automatic build related env vars set by `lifecycle`, which are only set at build time and not also at launch time:
https://github.com/buildpacks/spec/blob/main/buildpack.md#layer-paths