### PR TITLE
Always add the Pip dependencies layer `bin` directory to PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Stopped manually creating a `src` directory inside the Pip dependencies layer. Pip will create the directory itself if needed (when there are editable VCS dependencies). ([#228](https://github.com/heroku/buildpacks-python/pull/228))
 - Stopped setting `CPATH` and `PKG_CONFIG_PATH` at launch time. ([#231](https://github.com/heroku/buildpacks-python/pull/231))
+- The `bin` directory in the Pip dependencies layer is now always added to `PATH` instead of only when an installed dependency has an entry point script. ([#232](https://github.com/heroku/buildpacks-python/pull/232))
 
 ## [0.12.1] - 2024-07-15
 

--- a/tests/pip_test.rs
+++ b/tests/pip_test.rs
@@ -61,7 +61,7 @@ fn pip_basic_install_and_cache_reuse() {
             &formatdoc! {"
                 LANG=C.UTF-8
                 LD_LIBRARY_PATH=/layers/heroku_python/python/lib:/layers/heroku_python/dependencies/lib
-                PATH=/layers/heroku_python/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+                PATH=/layers/heroku_python/dependencies/bin:/layers/heroku_python/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
                 PIP_DISABLE_PIP_VERSION_CHECK=1
                 PYTHONHOME=/layers/heroku_python/python
                 PYTHONUNBUFFERED=1


### PR DESCRIPTION
Previously the `bin` directory would only be added to `PATH` if it existed (due to it being set by `lifecycle`), which is only the case if one of the installed dependencies has an entry point script, which causes Pip to create the `bin` directory and place a wrapper script inside it for that package's CLI command.

This meant:
1. We had to suppress Pip's warning during install (since Pip isn't to know that the `PATH` will be correctly set later)
2. If an app has no dependencies with an entry-point (so the app image doesn't have a `bin` directory), then at run-time tries to pip install a new package that does have an entry point (eg when debugging), then that new script won't be on `PATH`.

As such, we now add the `bin` directory to PATH explicitly, instead of relying on `lifecycle` automatic addition.