### PR TITLE
Expose the Pip cache layer to later buildpacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stopped manually creating a `src` directory inside the Pip dependencies layer. Pip will create the directory itself if needed (when there are editable VCS dependencies). ([#228](https://github.com/heroku/buildpacks-python/pull/228))
 - Stopped setting `CPATH` and `PKG_CONFIG_PATH` at launch time. ([#231](https://github.com/heroku/buildpacks-python/pull/231))
 - The `bin` directory in the Pip dependencies layer is now always added to `PATH` instead of only when an installed dependency has an entry point script. ([#232](https://github.com/heroku/buildpacks-python/pull/232))
+- The Pip cache layer is now exposed to Pip invocations in later buildpacks. ([#234](https://github.com/heroku/buildpacks-python/pull/234))
 
 ## [0.12.1] - 2024-07-15
 

--- a/src/layers/pip_dependencies.rs
+++ b/src/layers/pip_dependencies.rs
@@ -27,13 +27,12 @@ use std::process::Command;
 //   a requirements file is later removed, Pip will not uninstall the package. In addition,
 //   there is no official lockfile support, so changes in transitive dependencies add yet
 //   more opportunity for non-determinism between each install.
-// - The Pip HTTP/wheel cache is itself cached in a separate layer, which covers the most
-//   time consuming part of performing a pip install: downloading the dependencies and then
-//   generating wheels for any packages that don't provide them.
+// - The Pip HTTP/wheel cache is itself cached in a separate layer (exposed via `PIP_CACHE_DIR`),
+//   which covers the most time consuming part of performing a pip install: downloading the
+//   dependencies and then generating wheels for any packages that don't provide them.
 pub(crate) fn install_dependencies(
     context: &BuildContext<PythonBuildpack>,
     env: &mut Env,
-    pip_cache_dir: &Path,
 ) -> Result<PathBuf, libcnb::Error<BuildpackError>> {
     let layer = context.uncached_layer(
         layer_name!("dependencies"),
@@ -54,8 +53,6 @@ pub(crate) fn install_dependencies(
         Command::new("pip")
             .args([
                 "install",
-                "--cache-dir",
-                &pip_cache_dir.to_string_lossy(),
                 "--no-input",
                 "--progress-bar",
                 "off",

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,12 +76,13 @@ impl Buildpack for PythonBuildpack {
         let dependencies_layer_dir = match package_manager {
             PackageManager::Pip => {
                 log_header("Installing dependencies using Pip");
-                let pip_cache_dir = pip_cache::prepare_pip_cache(
+                pip_cache::prepare_pip_cache(
                     &context,
+                    &mut env,
                     &python_version,
                     &packaging_tool_versions,
                 )?;
-                pip_dependencies::install_dependencies(&context, &mut env, &pip_cache_dir)?
+                pip_dependencies::install_dependencies(&context, &mut env)?
             }
         };
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -45,6 +45,7 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
         ("LD_LIBRARY_PATH", "/invalid"),
         ("LIBRARY_PATH", "/invalid"),
         ("PATH", "/invalid"),
+        ("PIP_CACHE_DIR", "/invalid"),
         ("PIP_DISABLE_PIP_VERSION_CHECK", "0"),
         ("PKG_CONFIG_PATH", "/invalid"),
         ("PYTHONHOME", "/invalid"),


### PR DESCRIPTION
So that any pip invocations there can share the cache.

See:
https://pip.pypa.io/en/stable/cli/pip/#cmdoption-cache-dir
https://pip.pypa.io/en/stable/topics/caching/

GUS-W-16370362.