### PR TITLE
Install app dependencies into a virtual environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- App dependencies are now installed into a virtual environment instead of user site-packages. ([#257](https://github.com/heroku/buildpacks-python/pull/257))
+
 ## [0.15.0] - 2024-08-07
 
 ### Changed

--- a/tests/fixtures/pip_editable_git_compiled/requirements.txt
+++ b/tests/fixtures/pip_editable_git_compiled/requirements.txt
@@ -1,6 +1,6 @@
 # This requirement uses a VCS URL and `-e` in order to test that:
 #  - Git from the stack image can be found (ie: the system PATH has been correctly propagated to pip).
-#  - The editable mode repository clone is saved into the dependencies layer (via the `--src` option).
+#  - The editable mode repository clone is saved into the dependencies layer.
 #
 # A C-based package is used instead of a pure Python package, in order to test that the
 # Python headers can be found in the `include/pythonX.Y/` directory of the Python layer.

--- a/tests/fixtures/testing_buildpack/bin/build
+++ b/tests/fixtures/testing_buildpack/bin/build
@@ -5,8 +5,6 @@
 # - Python's sys.path is correct.
 # - The correct version of pip was installed.
 # - Both the package manager and Python can find the typing-extensions package.
-# - The system site-packages directory is protected against running 'pip install'
-#   without having passed '--user'.
 # - The typing-extensions package was installed into a separate dependencies layer.
 
 set -euo pipefail
@@ -20,5 +18,4 @@ python -c 'import pprint, sys; pprint.pp(sys.path)'
 echo
 pip --version
 pip list
-pip install --dry-run typing-extensions
 python -c 'import typing_extensions; print(typing_extensions)'

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -51,6 +51,7 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
         ("PYTHONHOME", "/invalid"),
         ("PYTHONPATH", "/invalid"),
         ("PYTHONUSERBASE", "/invalid"),
+        ("VIRTUAL_ENV", "/invalid"),
     ]);
 
     config

--- a/tests/pip_test.rs
+++ b/tests/pip_test.rs
@@ -27,7 +27,8 @@ fn pip_basic_install_and_cache_reuse() {
                 Installing pip {PIP_VERSION}
                 
                 [Installing dependencies using pip]
-                Running pip install
+                Creating virtual environment
+                Running 'pip install -r requirements.txt'
                 Collecting typing-extensions==4.12.2 (from -r requirements.txt (line 2))
                   Downloading typing_extensions-4.12.2-py3-none-any.whl.metadata (3.0 kB)
                 Downloading typing_extensions-4.12.2-py3-none-any.whl (37 kB)
@@ -35,34 +36,31 @@ fn pip_basic_install_and_cache_reuse() {
                 Successfully installed typing-extensions-4.12.2
                 
                 ## Testing buildpack ##
-                CPATH=/layers/heroku_python/python/include/python3.12:/layers/heroku_python/python/include
+                CPATH=/layers/heroku_python/venv/include:/layers/heroku_python/python/include/python3.12:/layers/heroku_python/python/include
                 LANG=C.UTF-8
-                LD_LIBRARY_PATH=/layers/heroku_python/python/lib:/layers/heroku_python/dependencies/lib
-                LIBRARY_PATH=/layers/heroku_python/python/lib:/layers/heroku_python/dependencies/lib
-                PATH=/layers/heroku_python/python/bin:/layers/heroku_python/dependencies/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+                LD_LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib
+                LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib
+                PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
                 PIP_CACHE_DIR=/layers/heroku_python/pip-cache
                 PIP_DISABLE_PIP_VERSION_CHECK=1
+                PIP_PYTHON=/layers/heroku_python/venv
                 PKG_CONFIG_PATH=/layers/heroku_python/python/lib/pkgconfig
                 PYTHONHOME=/layers/heroku_python/python
                 PYTHONUNBUFFERED=1
-                PYTHONUSERBASE=/layers/heroku_python/dependencies
                 SOURCE_DATE_EPOCH=315532801
+                VIRTUAL_ENV=/layers/heroku_python/venv
                 
                 ['',
                  '/layers/heroku_python/python/lib/python312.zip',
                  '/layers/heroku_python/python/lib/python3.12',
                  '/layers/heroku_python/python/lib/python3.12/lib-dynload',
-                 '/layers/heroku_python/dependencies/lib/python3.12/site-packages',
-                 '/layers/heroku_python/python/lib/python3.12/site-packages']
+                 '/layers/heroku_python/venv/lib/python3.12/site-packages']
                 
                 pip {PIP_VERSION} from /layers/heroku_python/python/lib/python3.12/site-packages/pip (python 3.12)
                 Package           Version
                 ----------------- -------
-                pip               {PIP_VERSION}
                 typing_extensions 4.12.2
-                Defaulting to user installation because normal site-packages is not writeable
-                Requirement already satisfied: typing-extensions in /layers/heroku_python/dependencies/lib/python3.12/site-packages (4.12.2)
-                <module 'typing_extensions' from '/layers/heroku_python/dependencies/lib/python3.12/site-packages/typing_extensions.py'>
+                <module 'typing_extensions' from '/layers/heroku_python/venv/lib/python3.12/site-packages/typing_extensions.py'>
             "}
         );
 
@@ -84,16 +82,16 @@ fn pip_basic_install_and_cache_reuse() {
             command_output.stdout,
             formatdoc! {"
                 LANG=C.UTF-8
-                LD_LIBRARY_PATH=/layers/heroku_python/python/lib:/layers/heroku_python/dependencies/lib
-                PATH=/layers/heroku_python/dependencies/bin:/layers/heroku_python/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+                LD_LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib
+                PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
                 PIP_DISABLE_PIP_VERSION_CHECK=1
+                PIP_PYTHON=/layers/heroku_python/venv
                 PYTHONHOME=/layers/heroku_python/python
                 PYTHONUNBUFFERED=1
-                PYTHONUSERBASE=/layers/heroku_python/dependencies
+                VIRTUAL_ENV=/layers/heroku_python/venv
                 
                 Package           Version
                 ----------------- -------
-                pip               {PIP_VERSION}
                 typing_extensions 4.12.2
             "}
         );
@@ -112,7 +110,8 @@ fn pip_basic_install_and_cache_reuse() {
                     
                     [Installing dependencies using pip]
                     Using cached pip download/wheel cache
-                    Running pip install
+                    Creating virtual environment
+                    Running 'pip install -r requirements.txt'
                     Collecting typing-extensions==4.12.2 (from -r requirements.txt (line 2))
                       Using cached typing_extensions-4.12.2-py3-none-any.whl.metadata (3.0 kB)
                     Using cached typing_extensions-4.12.2-py3-none-any.whl (37 kB)
@@ -148,7 +147,8 @@ fn pip_cache_invalidation_python_version_changed() {
                     
                     [Installing dependencies using pip]
                     Discarding cached pip download/wheel cache
-                    Running pip install
+                    Creating virtual environment
+                    Running 'pip install -r requirements.txt'
                     Collecting typing-extensions==4.12.2 (from -r requirements.txt (line 2))
                       Downloading typing_extensions-4.12.2-py3-none-any.whl.metadata (3.0 kB)
                     Downloading typing_extensions-4.12.2-py3-none-any.whl (37 kB)
@@ -190,7 +190,8 @@ fn pip_cache_previous_buildpack_version() {
                     
                     [Installing dependencies using pip]
                     Discarding cached pip download/wheel cache
-                    Running pip install
+                    Creating virtual environment
+                    Running 'pip install -r requirements.txt'
                     Collecting typing-extensions==4.12.2 (from -r requirements.txt (line 2))
                       Downloading typing_extensions-4.12.2-py3-none-any.whl.metadata (3.0 kB)
                     Downloading typing_extensions-4.12.2-py3-none-any.whl (37 kB)
@@ -217,7 +218,7 @@ fn pip_editable_git_compiled() {
     TestRunner::default().build(config, |context| {
         assert_contains!(
             context.pack_stdout,
-            "Cloning https://github.com/pypa/wheel.git (to revision 0.44.0) to /layers/heroku_python/dependencies/src/extension-dist"
+            "Cloning https://github.com/pypa/wheel.git (to revision 0.44.0) to /layers/heroku_python/venv/src/extension-dist"
         );
     });
 }
@@ -235,7 +236,8 @@ fn pip_install_error() {
             context.pack_stdout,
             indoc! {"
                 [Installing dependencies using pip]
-                Running pip install
+                Creating virtual environment
+                Running 'pip install -r requirements.txt'
             "}
         );
         assert_contains!(
@@ -246,8 +248,8 @@ fn pip_install_error() {
                                           ^ (from line 1 of requirements.txt)
                 
                 [Error: Unable to install dependencies using pip]
-                The 'pip install' command to install the application's dependencies from
-                'requirements.txt' failed (exit status: 1).
+                The 'pip install -r requirements.txt' command to install the app's
+                dependencies failed (exit status: 1).
                 
                 See the log output above for more information.
             "}


### PR DESCRIPTION
App dependencies are now installed into a Python virtual environment (aka venv / virtualenv) instead of into a custom user site-packages location.

This:
1. Avoids user site-packages compatibility issues with some packages when using relocated Python (see #253)
2. Improves parity with how dependencies will be installed when using Poetry in the future (since Poetry doesn't support `--user` installs)
3. Unblocks being able to move pip into its own layer (see #254)

This approach is possible since pip 22.3+ supports a new `--python` / `PIP_PYTHON` option which can be used to make pip operate against a different environment to the one in which it is installed. This allows us to continuing keeping pip in a separate layer to the app dependencies (currently the Python layer, but in a later PR pip will be moved to its own layer).

Now that app dependencies are installed into a venv, we no longer need to make the system site-packages directory read-only to protect against later buildpacks installing into the wrong location.

Note: For a venv to work, it depends upon the `<venv_layer>/bin/python` symlink being earlier in `PATH` than the main Python installation. To achieve that with CNBs, the venv's layer name must be alphabetically after the Python layer name. In addition, lifecycle 0.20.1+ is required, since earlier versions didn't implement the spec correctly during the execution of later buildpacks (see https://github.com/buildpacks/lifecycle/issues/1393).

This has been split out of the Poetry PR for easier review.

See also:
- https://docs.python.org/3/library/venv.html
- https://pip.pypa.io/en/stable/cli/pip/#cmdoption-python

Closes #253.
GUS-W-16616226.