### PR TITLE
Move pip into its own layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - App dependencies are now installed into a virtual environment instead of user site-packages. ([#257](https://github.com/heroku/buildpacks-python/pull/257))
+- pip is now installed into its own layer (as a user site-packages install) instead of into system site-packages in the Python layer. ([#258](https://github.com/heroku/buildpacks-python/pull/258))
 
 ## [0.15.0] - 2024-08-07
 

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod pip;
 pub(crate) mod pip_cache;
 pub(crate) mod pip_dependencies;
 pub(crate) mod python;

--- a/src/layers/pip.rs
+++ b/src/layers/pip.rs
@@ -1,0 +1,143 @@
+use crate::packaging_tool_versions::PIP_VERSION;
+use crate::python_version::PythonVersion;
+use crate::utils::StreamedCommandError;
+use crate::{utils, BuildpackError, PythonBuildpack};
+use libcnb::build::BuildContext;
+use libcnb::data::layer_name;
+use libcnb::layer::{
+    CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerState, RestoredLayerAction,
+};
+use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
+use libcnb::Env;
+use libherokubuildpack::log::log_info;
+use serde::{Deserialize, Serialize};
+use std::io;
+use std::path::Path;
+use std::process::Command;
+
+/// Creates a layer containing pip.
+pub(crate) fn install_pip(
+    context: &BuildContext<PythonBuildpack>,
+    env: &mut Env,
+    python_version: &PythonVersion,
+    python_layer_path: &Path,
+) -> Result<(), libcnb::Error<BuildpackError>> {
+    let new_metadata = PipLayerMetadata {
+        python_version: python_version.to_string(),
+        pip_version: PIP_VERSION.to_string(),
+    };
+
+    let layer = context.cached_layer(
+        layer_name!("pip"),
+        CachedLayerDefinition {
+            build: true,
+            launch: true,
+            invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
+            restored_layer_action: &|cached_metadata: &PipLayerMetadata, _| {
+                let cached_pip_version = cached_metadata.pip_version.clone();
+                if cached_metadata == &new_metadata {
+                    (RestoredLayerAction::KeepLayer, cached_pip_version)
+                } else {
+                    (RestoredLayerAction::DeleteLayer, cached_pip_version)
+                }
+            },
+        },
+    )?;
+
+    let mut layer_env = LayerEnv::new()
+        // We use a curated pip version, so disable the update check to speed up pip invocations,
+        // reduce build log spam and prevent users from thinking they need to manually upgrade.
+        // https://pip.pypa.io/en/stable/cli/pip/#cmdoption-disable-pip-version-check
+        .chainable_insert(
+            Scope::All,
+            ModificationBehavior::Override,
+            "PIP_DISABLE_PIP_VERSION_CHECK",
+            "1",
+        )
+        // Move the Python user base directory to this layer instead of under HOME:
+        // https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUSERBASE
+        .chainable_insert(
+            Scope::All,
+            ModificationBehavior::Override,
+            "PYTHONUSERBASE",
+            layer.path(),
+        );
+
+    match layer.state {
+        LayerState::Restored {
+            cause: ref cached_pip_version,
+        } => {
+            log_info(format!("Using cached pip {cached_pip_version}"));
+        }
+        LayerState::Empty { ref cause } => {
+            match cause {
+                EmptyLayerCause::InvalidMetadataAction { .. } => {
+                    log_info("Discarding cached pip since its layer metadata can't be parsed");
+                }
+                EmptyLayerCause::RestoredLayerAction {
+                    cause: cached_pip_version,
+                } => {
+                    log_info(format!("Discarding cached pip {cached_pip_version}"));
+                }
+                EmptyLayerCause::NewlyCreated => {}
+            }
+
+            log_info(format!("Installing pip {PIP_VERSION}"));
+
+            // We use the pip wheel bundled within Python's standard library to install our chosen
+            // pip version, since it's faster than `ensurepip` followed by an upgrade in place.
+            let bundled_pip_module_path =
+                utils::bundled_pip_module_path(python_layer_path, python_version)
+                    .map_err(PipLayerError::LocateBundledPip)?;
+
+            utils::run_command_and_stream_output(
+                Command::new("python")
+                    .args([
+                        &bundled_pip_module_path.to_string_lossy(),
+                        "install",
+                        // There is no point using pip's cache here, since the layer itself will be cached.
+                        "--no-cache-dir",
+                        "--no-input",
+                        "--no-warn-script-location",
+                        "--quiet",
+                        "--user",
+                        format!("pip=={PIP_VERSION}").as_str(),
+                    ])
+                    .env_clear()
+                    .envs(&layer_env.apply(Scope::Build, env)),
+            )
+            .map_err(PipLayerError::InstallPipCommand)?;
+
+            layer.write_metadata(new_metadata)?;
+        }
+    }
+
+    layer.write_env(&layer_env)?;
+    // Required to pick up the automatic PATH env var. See: https://github.com/heroku/libcnb.rs/issues/842
+    layer_env = layer.read_env()?;
+    env.clone_from(&layer_env.apply(Scope::Build, env));
+
+    Ok(())
+}
+
+// pip's wheel is a pure Python package with no dependencies, so the layer is not arch or distro
+// specific. However, the generated .pyc files vary by Python version.
+#[derive(Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct PipLayerMetadata {
+    python_version: String,
+    pip_version: String,
+}
+
+/// Errors that can occur when installing pip into a layer.
+#[derive(Debug)]
+pub(crate) enum PipLayerError {
+    InstallPipCommand(StreamedCommandError),
+    LocateBundledPip(io::Error),
+}
+
+impl From<PipLayerError> for libcnb::Error<BuildpackError> {
+    fn from(error: PipLayerError) -> Self {
+        Self::BuildpackError(BuildpackError::PipLayer(error))
+    }
+}

--- a/src/layers/pip_cache.rs
+++ b/src/layers/pip_cache.rs
@@ -34,9 +34,9 @@ pub(crate) fn prepare_pip_cache(
             invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
             restored_layer_action: &|cached_metadata: &PipCacheLayerMetadata, _| {
                 if cached_metadata == &new_metadata {
-                    Ok(RestoredLayerAction::KeepLayer)
+                    RestoredLayerAction::KeepLayer
                 } else {
-                    Ok(RestoredLayerAction::DeleteLayer)
+                    RestoredLayerAction::DeleteLayer
                 }
             },
         },

--- a/tests/fixtures/testing_buildpack/bin/build
+++ b/tests/fixtures/testing_buildpack/bin/build
@@ -3,7 +3,7 @@
 # Check that:
 # - The correct env vars are set for later buildpacks.
 # - Python's sys.path is correct.
-# - The correct version of pip was installed.
+# - The correct version of pip was installed, into its own layer.
 # - Both the package manager and Python can find the typing-extensions package.
 # - The typing-extensions package was installed into a separate dependencies layer.
 

--- a/tests/pip_test.rs
+++ b/tests/pip_test.rs
@@ -22,8 +22,10 @@ fn pip_basic_install_and_cache_reuse() {
                 No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
                 To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
                 
-                [Installing Python and pip]
+                [Installing Python]
                 Installing Python {DEFAULT_PYTHON_VERSION}
+                
+                [Installing pip]
                 Installing pip {PIP_VERSION}
                 
                 [Installing dependencies using pip]
@@ -38,15 +40,16 @@ fn pip_basic_install_and_cache_reuse() {
                 ## Testing buildpack ##
                 CPATH=/layers/heroku_python/venv/include:/layers/heroku_python/python/include/python3.12:/layers/heroku_python/python/include
                 LANG=C.UTF-8
-                LD_LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib
-                LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib
-                PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+                LD_LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib:/layers/heroku_python/pip/lib
+                LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib:/layers/heroku_python/pip/lib
+                PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/layers/heroku_python/pip/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
                 PIP_CACHE_DIR=/layers/heroku_python/pip-cache
                 PIP_DISABLE_PIP_VERSION_CHECK=1
                 PIP_PYTHON=/layers/heroku_python/venv
                 PKG_CONFIG_PATH=/layers/heroku_python/python/lib/pkgconfig
                 PYTHONHOME=/layers/heroku_python/python
                 PYTHONUNBUFFERED=1
+                PYTHONUSERBASE=/layers/heroku_python/pip
                 SOURCE_DATE_EPOCH=315532801
                 VIRTUAL_ENV=/layers/heroku_python/venv
                 
@@ -56,7 +59,7 @@ fn pip_basic_install_and_cache_reuse() {
                  '/layers/heroku_python/python/lib/python3.12/lib-dynload',
                  '/layers/heroku_python/venv/lib/python3.12/site-packages']
                 
-                pip {PIP_VERSION} from /layers/heroku_python/python/lib/python3.12/site-packages/pip (python 3.12)
+                pip {PIP_VERSION} from /layers/heroku_python/pip/lib/python3.12/site-packages/pip (python 3.12)
                 Package           Version
                 ----------------- -------
                 typing_extensions 4.12.2
@@ -82,12 +85,13 @@ fn pip_basic_install_and_cache_reuse() {
             command_output.stdout,
             formatdoc! {"
                 LANG=C.UTF-8
-                LD_LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib
-                PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+                LD_LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib:/layers/heroku_python/pip/lib
+                PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/layers/heroku_python/pip/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
                 PIP_DISABLE_PIP_VERSION_CHECK=1
                 PIP_PYTHON=/layers/heroku_python/venv
                 PYTHONHOME=/layers/heroku_python/python
                 PYTHONUNBUFFERED=1
+                PYTHONUSERBASE=/layers/heroku_python/pip
                 VIRTUAL_ENV=/layers/heroku_python/venv
                 
                 Package           Version
@@ -105,8 +109,11 @@ fn pip_basic_install_and_cache_reuse() {
                     No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
                     To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
                     
-                    [Installing Python and pip]
-                    Using cached Python {DEFAULT_PYTHON_VERSION} and pip {PIP_VERSION}
+                    [Installing Python]
+                    Using cached Python {DEFAULT_PYTHON_VERSION}
+                    
+                    [Installing pip]
+                    Using cached pip {PIP_VERSION}
                     
                     [Installing dependencies using pip]
                     Using cached pip download/wheel cache
@@ -139,10 +146,13 @@ fn pip_cache_invalidation_python_version_changed() {
                     No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
                     To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
                     
-                    [Installing Python and pip]
-                    Discarding cache since:
+                    [Installing Python]
+                    Discarding cached Python {LATEST_PYTHON_3_11} since:
                      - The Python version has changed from {LATEST_PYTHON_3_11} to {DEFAULT_PYTHON_VERSION}
                     Installing Python {DEFAULT_PYTHON_VERSION}
+                    
+                    [Installing pip]
+                    Discarding cached pip {PIP_VERSION}
                     Installing pip {PIP_VERSION}
                     
                     [Installing dependencies using pip]
@@ -181,11 +191,11 @@ fn pip_cache_previous_buildpack_version() {
                     No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
                     To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
                     
-                    [Installing Python and pip]
-                    Discarding cache since:
-                     - The Python version has changed from 3.12.4 to {DEFAULT_PYTHON_VERSION}
-                     - The pip version has changed from 24.1.2 to {PIP_VERSION}
+                    [Installing Python]
+                    Discarding cached Python since its layer metadata can't be parsed
                     Installing Python {DEFAULT_PYTHON_VERSION}
+                    
+                    [Installing pip]
                     Installing pip {PIP_VERSION}
                     
                     [Installing dependencies using pip]

--- a/tests/python_version_test.rs
+++ b/tests/python_version_test.rs
@@ -1,4 +1,3 @@
-use crate::packaging_tool_versions::PIP_VERSION;
 use crate::tests::{
     builder, default_build_config, DEFAULT_PYTHON_VERSION, LATEST_PYTHON_3_10, LATEST_PYTHON_3_11,
     LATEST_PYTHON_3_12, LATEST_PYTHON_3_7, LATEST_PYTHON_3_8, LATEST_PYTHON_3_9,
@@ -20,7 +19,7 @@ fn python_version_unspecified() {
                     No Python version specified, using the current default of Python {DEFAULT_PYTHON_VERSION}.
                     To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
                     
-                    [Installing Python and pip]
+                    [Installing Python]
                     Installing Python {DEFAULT_PYTHON_VERSION}
                 "}
             );
@@ -86,9 +85,8 @@ fn builds_with_python_version(fixture_path: &str, python_version: &str) {
                 [Determining Python version]
                 Using Python version {python_version} specified in runtime.txt
                 
-                [Installing Python and pip]
+                [Installing Python]
                 Installing Python {python_version}
-                Installing pip {PIP_VERSION}
             "}
         );
         // There's no sensible default process type we can set for Python apps.
@@ -193,7 +191,7 @@ fn runtime_txt_non_existent_version() {
 
 fn rejects_non_existent_python_version(fixture_path: &str, python_version: &str) {
     TestRunner::default().build(
-        default_build_config( fixture_path).expected_pack_result(PackResult::Failure),
+        default_build_config(fixture_path).expected_pack_result(PackResult::Failure),
         |context| {
             assert_contains!(
                 context.pack_stderr,


### PR DESCRIPTION
pip is now installed into its own layer (as a user site-packages install) instead of into system site-packages in the Python layer.

This is possible now that the user site-packages location is no longer being used for app dependencies, after the switch to venvs in #257.

pip being in its own layer has the following advantages:
1. We can more easily exclude pip from the build/run images when using other packages managers (such as for the upcoming Poetry support).
2. A change in pip version no longer unnecessarily invalidates the Python layer.
3. In the future we could more easily exclude pip from the run image entirely, should we wish (see #255).

This has been split out of the Poetry PR for easier review.

Closes #254.
GUS-W-16616956.