### PR TITLE
Stop including pip in the final app image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- pip is now only available during the build, and is longer included in the final app image. ([#264](https://github.com/heroku/buildpacks-python/pull/264))
+
 ## [0.17.1] - 2024-09-07
 
 ### Changed

--- a/src/layers/pip.rs
+++ b/src/layers/pip.rs
@@ -31,7 +31,7 @@ pub(crate) fn install_pip(
         layer_name!("pip"),
         CachedLayerDefinition {
             build: true,
-            launch: true,
+            launch: false,
             invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
             restored_layer_action: &|cached_metadata: &PipLayerMetadata, _| {
                 let cached_pip_version = cached_metadata.pip_version.clone();
@@ -49,7 +49,7 @@ pub(crate) fn install_pip(
         // reduce build log spam and prevent users from thinking they need to manually upgrade.
         // https://pip.pypa.io/en/stable/cli/pip/#cmdoption-disable-pip-version-check
         .chainable_insert(
-            Scope::All,
+            Scope::Build,
             ModificationBehavior::Override,
             "PIP_DISABLE_PIP_VERSION_CHECK",
             "1",
@@ -57,7 +57,7 @@ pub(crate) fn install_pip(
         // Move the Python user base directory to this layer instead of under HOME:
         // https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUSERBASE
         .chainable_insert(
-            Scope::All,
+            Scope::Build,
             ModificationBehavior::Override,
             "PYTHONUSERBASE",
             layer.path(),


### PR DESCRIPTION
After #254, pip is now installed into its own layer rather than into the system site-packages directory inside the Python layer.

This means its now possible to exclude pip from the final app image, by making the pip layer be a [build-only layer](https://buildpacks.io/docs/for-buildpack-authors/concepts/caching-strategies/).

Excluding pip from the final app image:
- Prevents several classes of user error/confusion/bad app design patterns seen in support tickets (see #255 for more details).
- Reduces app image supply chain surface area.
- Reduces app image size by 13 MB and layer count by 1, meaning less to have to push to a remote registry.
- Matches the approach used for Poetry, where we don't make Poetry available at run-time either.

Users that need pip at run-time for a temporary debugging task can run `python -m ensurepip --default-pip` in the container at run-time to make it available again (this command doesn't even have to download anything - it uses the pip bundled with Python).

Or if pip is an actual run-time dependency of the app, then the app can add `pip` to its `requirements.txt` (which much more clearly conveys the requirements of the app, and also allows the app to pick what pip version it needs at run-time - something that isn't possible with the pip installed by the buildpack).

Should we find that pip's absence causes confusion in the future, we could always add a wrapper/shim `pip` script in the app image which does something like `echo "pip isn't installed at run-time, if you need it temporarily run 'python -m ensurepip --default-pip' to install it" && exit 1` to improve discoverability. We'll also document pip (and Poetry) being available at build-time only in the docs that will be added by #11.

Closes #255.
GUS-W-16697386.