### PR TITLE
Fix CHANGELOG typo for v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- pip is now only available during the build, and is longer included in the final app image. ([#264](https://github.com/heroku/buildpacks-python/pull/264))
+- pip is now only available during the build, and is no longer included in the final app image. ([#264](https://github.com/heroku/buildpacks-python/pull/264))
 - Improved the error messages shown when an end-of-life or unknown Python version is requested. ([#272](https://github.com/heroku/buildpacks-python/pull/272))
 
 ## [0.17.1] - 2024-09-07


### PR DESCRIPTION
`s/longer/no longer/`