### PR TITLE
Update Python 3.12 to 3.12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the Python 3.12 version alias to Python 3.12.7. ([#276](https://github.com/heroku/buildpacks-python/pull/276))
+
 ## [0.18.0] - 2024-09-17
 
 ### Added

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -19,7 +19,7 @@ pub(crate) const LATEST_PYTHON_3_8: PythonVersion = PythonVersion::new(3, 8, 20)
 pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 20);
 pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 15);
 pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 10);
-pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 6);
+pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 7);
 
 /// The Python version that was requested for a project.
 #[derive(Clone, Debug, PartialEq)]

--- a/tests/python_version_test.rs
+++ b/tests/python_version_test.rs
@@ -356,7 +356,7 @@ fn runtime_txt_invalid_version() {
                 However, the file contents must begin with a 'python-' prefix, followed by the
                 version specified as '<major>.<minor>.<patch>'. Comments are not supported.
                 
-                For example, to request Python 3.12.6, update the 'runtime.txt' file so it
+                For example, to request Python {DEFAULT_PYTHON_FULL_VERSION}, update the 'runtime.txt' file so it
                 contains exactly:
                 python-{DEFAULT_PYTHON_FULL_VERSION}
             "}


### PR DESCRIPTION
Release announcement:
https://www.python.org/downloads/release/python-3127/

Changelog:
https://docs.python.org/3.12/whatsnew/changelog.html#python-3-12-7-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/11119534362

GUS-W-14846795.