### PR TITLE
Add support for Python 3.13.1, 3.12.8, 3.11.11, 3.10.16 and 3.9.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Python 3.13 version alias now resolves to Python 3.13.1. ([#297](https://github.com/heroku/buildpacks-python/pull/297))
+- The Python 3.12 version alias now resolves to Python 3.12.8. ([#297](https://github.com/heroku/buildpacks-python/pull/297))
+- The Python 3.11 version alias now resolves to Python 3.11.11. ([#297](https://github.com/heroku/buildpacks-python/pull/297))
+- The Python 3.10 version alias now resolves to Python 3.10.16. ([#297](https://github.com/heroku/buildpacks-python/pull/297))
+- The Python 3.9 version alias now resolves to Python 3.9.21. ([#297](https://github.com/heroku/buildpacks-python/pull/297))
+
 ## [0.19.1] - 2024-11-04
 
 ### Changed
@@ -24,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated the Python 3.12 version alias to Python 3.12.7. ([#276](https://github.com/heroku/buildpacks-python/pull/276))
+- The Python 3.12 version alias now resolves to Python 3.12.7. ([#276](https://github.com/heroku/buildpacks-python/pull/276))
 
 ## [0.18.0] - 2024-09-17
 

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -16,11 +16,11 @@ pub(crate) const DEFAULT_PYTHON_VERSION: RequestedPythonVersion = RequestedPytho
 pub(crate) const DEFAULT_PYTHON_FULL_VERSION: PythonVersion = LATEST_PYTHON_3_12;
 
 pub(crate) const LATEST_PYTHON_3_8: PythonVersion = PythonVersion::new(3, 8, 20);
-pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 20);
-pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 15);
-pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 10);
-pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 7);
-pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 0);
+pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 21);
+pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 16);
+pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 11);
+pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 8);
+pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 1);
 
 /// The Python version that was requested for a project.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2024/12/python-3131-3128-31111-31016-and-3921.html

Changelog:
https://docs.python.org/3.13/whatsnew/changelog.html#python-3-13-1-final
https://docs.python.org/3.12/whatsnew/changelog.html#python-3-12-8-final
https://docs.python.org/release/3.11.11/whatsnew/changelog.html#python-3-11-11-final
https://docs.python.org/release/3.10.16/whatsnew/changelog.html#python-3-10-16-final
https://docs.python.org/release/3.9.21/whatsnew/changelog.html#python-3-9-21-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/12159159015
https://github.com/heroku/heroku-buildpack-python/actions/runs/12159160169
https://github.com/heroku/heroku-buildpack-python/actions/runs/12159161685
https://github.com/heroku/heroku-buildpack-python/actions/runs/12162379421
https://github.com/heroku/heroku-buildpack-python/actions/runs/12159164423

GUS-W-14846804.
GUS-W-17350158.
GUS-W-17367727.