### PR TITLE
Stop setting the `LANG` env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Stopped setting the `LANG` env var. ([#306](https://github.com/heroku/buildpacks-python/pull/306))
+
 ## [0.20.1] - 2024-12-13
 
 ### Fixed

--- a/src/layers/python.rs
+++ b/src/layers/python.rs
@@ -176,14 +176,6 @@ fn generate_layer_env(layer_path: &Path, python_version: &PythonVersion) -> Laye
             )),
         )
         .chainable_insert(Scope::Build, ModificationBehavior::Delimiter, "CPATH", ":")
-        // Ensure Python uses a Unicode locale, to prevent the issues described in:
-        // https://github.com/docker-library/python/pull/570
-        .chainable_insert(
-            Scope::All,
-            ModificationBehavior::Override,
-            "LANG",
-            "C.UTF-8",
-        )
         // We have to set `PKG_CONFIG_PATH` explicitly, since the automatic path set by lifecycle/libcnb
         // is `<layer>/pkgconfig/`, whereas Python's pkgconfig files are at `<layer>/lib/pkgconfig/`.
         .chainable_insert(
@@ -330,7 +322,6 @@ mod tests {
     fn python_layer_env() {
         let mut base_env = Env::new();
         base_env.insert("CPATH", "/base");
-        base_env.insert("LANG", "this-should-be-overridden");
         base_env.insert("PKG_CONFIG_PATH", "/base");
         base_env.insert("PYTHONHOME", "this-should-be-overridden");
         base_env.insert("PYTHONUNBUFFERED", "this-should-be-overridden");
@@ -341,7 +332,6 @@ mod tests {
             utils::environment_as_sorted_vector(&layer_env.apply(Scope::Build, &base_env)),
             [
                 ("CPATH", "/layer-dir/include/python3.11:/base"),
-                ("LANG", "C.UTF-8"),
                 ("PKG_CONFIG_PATH", "/layer-dir/lib/pkgconfig:/base"),
                 ("PYTHONHOME", "/layer-dir"),
                 ("PYTHONUNBUFFERED", "1"),
@@ -352,7 +342,6 @@ mod tests {
             utils::environment_as_sorted_vector(&layer_env.apply(Scope::Launch, &base_env)),
             [
                 ("CPATH", "/base"),
-                ("LANG", "C.UTF-8"),
                 ("PKG_CONFIG_PATH", "/base"),
                 ("PYTHONHOME", "/layer-dir"),
                 ("PYTHONUNBUFFERED", "1"),

--- a/tests/pip_test.rs
+++ b/tests/pip_test.rs
@@ -40,7 +40,6 @@ fn pip_basic_install_and_cache_reuse() {
                 
                 ## Testing buildpack ##
                 CPATH=/layers/heroku_python/venv/include:/layers/heroku_python/python/include/python3.13:/layers/heroku_python/python/include
-                LANG=C.UTF-8
                 LD_LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib:/layers/heroku_python/pip/lib
                 LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib:/layers/heroku_python/pip/lib
                 PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/layers/heroku_python/pip/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -84,7 +83,6 @@ fn pip_basic_install_and_cache_reuse() {
         assert_eq!(
             command_output.stdout,
             formatdoc! {"
-                LANG=C.UTF-8
                 LD_LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib
                 PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
                 PIP_PYTHON=/layers/heroku_python/venv

--- a/tests/poetry_test.rs
+++ b/tests/poetry_test.rs
@@ -38,7 +38,6 @@ fn poetry_basic_install_and_cache_reuse() {
                 
                 ## Testing buildpack ##
                 CPATH=/layers/heroku_python/venv/include:/layers/heroku_python/python/include/python3.13:/layers/heroku_python/python/include
-                LANG=C.UTF-8
                 LD_LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib:/layers/heroku_python/poetry/lib
                 LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib:/layers/heroku_python/poetry/lib
                 PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/layers/heroku_python/poetry/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -77,7 +76,6 @@ fn poetry_basic_install_and_cache_reuse() {
         assert_eq!(
             command_output.stdout,
             formatdoc! {"
-                LANG=C.UTF-8
                 LD_LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib
                 PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
                 PYTHONHOME=/layers/heroku_python/python


### PR DESCRIPTION
Previously the buildpack would set the `LANG` env var at build and run time to the value `C.UTF-8`, to match the official Docker Python images.

However, the env var should not be needed for modern Python, and so the official Docker Python images no longer set it: 
https://github.com/docker-library/python/issues/887
https://github.com/docker-library/python/pull/895

In addition, the older issues typically only affected other distros such as alpine, or environments where someone had overridden the system locale, which doesn't apply to the Heroku base images.

GUS-W-17443565.