### PR TITLE
Stop setting the `PYTHONHOME` env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Stopped setting the `LANG` env var. ([#306](https://github.com/heroku/buildpacks-python/pull/306))
+- Stopped setting the `PYTHONHOME` env var. ([#309](https://github.com/heroku/buildpacks-python/pull/309))
 
 ## [0.20.1] - 2024-12-13
 

--- a/tests/pip_test.rs
+++ b/tests/pip_test.rs
@@ -47,7 +47,6 @@ fn pip_basic_install_and_cache_reuse() {
                 PIP_DISABLE_PIP_VERSION_CHECK=1
                 PIP_PYTHON=/layers/heroku_python/venv
                 PKG_CONFIG_PATH=/layers/heroku_python/python/lib/pkgconfig
-                PYTHONHOME=/layers/heroku_python/python
                 PYTHONUNBUFFERED=1
                 PYTHONUSERBASE=/layers/heroku_python/pip
                 SOURCE_DATE_EPOCH=315532801
@@ -85,7 +84,6 @@ fn pip_basic_install_and_cache_reuse() {
             formatdoc! {"
                 LD_LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib
                 PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-                PYTHONHOME=/layers/heroku_python/python
                 PYTHONUNBUFFERED=1
                 VIRTUAL_ENV=/layers/heroku_python/venv
             "}

--- a/tests/poetry_test.rs
+++ b/tests/poetry_test.rs
@@ -42,7 +42,6 @@ fn poetry_basic_install_and_cache_reuse() {
                 LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib:/layers/heroku_python/poetry/lib
                 PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/layers/heroku_python/poetry/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
                 PKG_CONFIG_PATH=/layers/heroku_python/python/lib/pkgconfig
-                PYTHONHOME=/layers/heroku_python/python
                 PYTHONUNBUFFERED=1
                 PYTHONUSERBASE=/layers/heroku_python/poetry
                 SOURCE_DATE_EPOCH=315532801
@@ -78,7 +77,6 @@ fn poetry_basic_install_and_cache_reuse() {
             formatdoc! {"
                 LD_LIBRARY_PATH=/layers/heroku_python/venv/lib:/layers/heroku_python/python/lib
                 PATH=/layers/heroku_python/venv/bin:/layers/heroku_python/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-                PYTHONHOME=/layers/heroku_python/python
                 PYTHONUNBUFFERED=1
                 VIRTUAL_ENV=/layers/heroku_python/venv
             "}


### PR DESCRIPTION
Since it was only set to work around a uWSGI bug, and that bug does not occur when using a venv (which we now use as of #257).

Closes #265.
GUS-W-17454520.