### PR TITLE
Expand buildpack detection known file list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack detection now recognises more Python-related file and directory names. ([#312](https://github.com/heroku/buildpacks-python/pull/312))
+
 ## [0.21.0] - 2024-12-18
 
 ### Changed

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -7,8 +7,9 @@ use std::path::Path;
 /// This list is deliberately larger than just the list of supported package manager files,
 /// so that Python projects that are missing some of the required files still pass detection,
 /// allowing us to show a helpful error message during the build phase.
-const KNOWN_PYTHON_PROJECT_FILES: [&str; 14] = [
+const KNOWN_PYTHON_PROJECT_FILES: [&str; 23] = [
     ".python-version",
+    "__init__.py",
     "app.py",
     "main.py",
     "manage.py",
@@ -19,9 +20,22 @@ const KNOWN_PYTHON_PROJECT_FILES: [&str; 14] = [
     "pyproject.toml",
     "requirements.txt",
     "runtime.txt",
+    "server.py",
     "setup.cfg",
     "setup.py",
     "uv.lock",
+    // Commonly seen misspellings of requirements.txt. (Which occur since pip doesn't
+    // create/manage requirements files itself, so the filenames are manually typed.)
+    "requirement.txt",
+    "Requirements.txt",
+    "requirements.text",
+    "requirements.txt.txt",
+    "requirments.txt",
+    // Whilst virtual environments shouldn't be committed to Git (and so shouldn't
+    // normally be present during the build), they are often present for beginner
+    // Python apps that are missing all of the other Python related files above.
+    ".venv/",
+    "venv/",
 ];
 
 /// Returns whether the specified project directory is that of a Python project, and so


### PR DESCRIPTION
This adds more Python project related file and directory names to the list recognised by buildpack detection. Such apps will still fail to build successfully (since they are missing a package manager file), but will now be shown a more helpful error message during compile, rather than the generic:
"No default language could be detected for this app"

The list is based on builds logs analysis of builds that filed to pass detection, plus builds that passed detection but didn't have a valid package manager file. (Possible since the build logs error message includes a file listing of the root directory of the app.)

This is the CNB equivalent of heroku/heroku-buildpack-python#1729.

GUS-W-17530142.