### PR TITLE
Deprecate Python 3.9 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Deprecated support for Python 3.9. ([#314](https://github.com/heroku/buildpacks-python/pull/314))
 - Buildpack detection now recognises more Python-related file and directory names. ([#312](https://github.com/heroku/buildpacks-python/pull/312))
 - Improved the error messages shown for EOL or unrecognised major Python versions. ([#313](https://github.com/heroku/buildpacks-python/pull/313))
 

--- a/tests/django_test.rs
+++ b/tests/django_test.rs
@@ -34,7 +34,7 @@ fn django_staticfiles_legacy_django() {
     TestRunner::default().build(
         default_build_config("tests/fixtures/django_staticfiles_legacy_django"),
         |context| {
-            assert_empty!(context.pack_stderr);
+            // We can't `assert_empty!(context.pack_stderr)` here, due to the Python 3.9 deprecation warning.
             assert_contains!(
                 context.pack_stdout,
                 indoc! {"


### PR DESCRIPTION
In accordance with the Python version support policy:
https://devcenter.heroku.com/articles/python-support#python-version-support-policy

See also:
https://devcenter.heroku.com/changelog-items/3095
https://github.com/heroku/heroku-buildpack-python/pull/1732

GUS-W-14846951.