### PR TITLE
Support major Python version syntax in `runtime.txt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `runtime.txt` support for the `python-3.X` major Python version form. ([#322](https://github.com/heroku/buildpacks-python/pull/322))
 - Enabled `libcnb`'s `trace` feature. ([#320](https://github.com/heroku/buildpacks-python/pull/320))
 
 ## [0.23.0] - 2025-01-13

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,7 +8,7 @@ use crate::layers::python::PythonLayerError;
 use crate::package_manager::DeterminePackageManagerError;
 use crate::python_version::{
     RequestedPythonVersion, RequestedPythonVersionError, ResolvePythonVersionError,
-    DEFAULT_PYTHON_FULL_VERSION, DEFAULT_PYTHON_VERSION, NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION,
+    DEFAULT_PYTHON_VERSION, NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION,
     OLDEST_SUPPORTED_PYTHON_3_MINOR_VERSION,
 };
 use crate::python_version_file::ParsePythonVersionFileError;
@@ -205,17 +205,22 @@ fn on_requested_python_version_error(error: RequestedPythonVersionError) {
             log_error(
                 "Invalid Python version in runtime.txt",
                 formatdoc! {"
-                    The Python version specified in 'runtime.txt' is not in the correct format.
+                    The Python version specified in 'runtime.txt' isn't in
+                    the correct format.
                     
                     The following file contents were found:
                     {cleaned_contents}
                     
-                    However, the file contents must begin with a 'python-' prefix, followed by the
-                    version specified as '<major>.<minor>.<patch>'. Comments are not supported.
+                    However, the version must be specified as either:
+                    1. 'python-<major>.<minor>' (recommended, for automatic updates)
+                    2. 'python-<major>.<minor>.<patch>' (to pin to an exact version)
                     
-                    For example, to request Python {DEFAULT_PYTHON_FULL_VERSION}, update the 'runtime.txt' file so it
-                    contains exactly:
-                    python-{DEFAULT_PYTHON_FULL_VERSION}
+                    Remember to include the 'python-' prefix. Comments aren't
+                    supported.
+                    
+                    For example, to request the latest version of Python {DEFAULT_PYTHON_VERSION},
+                    update the 'runtime.txt' file so it contains:
+                    python-{DEFAULT_PYTHON_VERSION}
                 "},
             );
         }

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -13,6 +13,8 @@ pub(crate) const DEFAULT_PYTHON_VERSION: RequestedPythonVersion = RequestedPytho
     patch: None,
     origin: PythonVersionOrigin::BuildpackDefault,
 };
+
+#[cfg(test)]
 pub(crate) const DEFAULT_PYTHON_FULL_VERSION: PythonVersion = LATEST_PYTHON_3_13;
 
 pub(crate) const OLDEST_SUPPORTED_PYTHON_3_MINOR_VERSION: u16 = 9;

--- a/tests/python_version_test.rs
+++ b/tests/python_version_test.rs
@@ -392,17 +392,22 @@ fn runtime_txt_invalid_version() {
             context.pack_stderr,
             &formatdoc! {"
                 [Error: Invalid Python version in runtime.txt]
-                The Python version specified in 'runtime.txt' is not in the correct format.
+                The Python version specified in 'runtime.txt' isn't in
+                the correct format.
                 
                 The following file contents were found:
                 python-an.invalid.version
                 
-                However, the file contents must begin with a 'python-' prefix, followed by the
-                version specified as '<major>.<minor>.<patch>'. Comments are not supported.
+                However, the version must be specified as either:
+                1. 'python-<major>.<minor>' (recommended, for automatic updates)
+                2. 'python-<major>.<minor>.<patch>' (to pin to an exact version)
                 
-                For example, to request Python {DEFAULT_PYTHON_FULL_VERSION}, update the 'runtime.txt' file so it
-                contains exactly:
-                python-{DEFAULT_PYTHON_FULL_VERSION}
+                Remember to include the 'python-' prefix. Comments aren't
+                supported.
+                
+                For example, to request the latest version of Python {DEFAULT_PYTHON_VERSION},
+                update the 'runtime.txt' file so it contains:
+                python-{DEFAULT_PYTHON_VERSION}
             "}
         );
     });


### PR DESCRIPTION
Historically the `runtime.txt` file has only supported specifying an exact Python version, in the form `python-3.X.Y`.

This adds support for the `python-3.X` form too, which means the app will automatically receive new Python patch updates during subsequent builds (similar to what's already supported for the `.python-version` file).

This means the Python CNB's `runtime.txt` supported syntax now matches that supported by the classic Python buildpack (which gained support for the major version form as part of adding support for the `.python-version` file in https://github.com/heroku/heroku-buildpack-python/pull/1664).

The `runtime.txt` file remains deprecated (a deprecation warning will be added shortly: https://github.com/heroku/buildpacks-python/issues/275), however, in the meantime this improves parity between the classic buildpack and CNB.

GUS-W-17660224.