### PR TITLE
Add support for Python 3.13.2 and 3.12.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The Python 3.13 version alias now resolves to Python 3.13.2. ([#326](https://github.com/heroku/buildpacks-python/pull/326))
+- The Python 3.12 version alias now resolves to Python 3.12.9. ([#326](https://github.com/heroku/buildpacks-python/pull/326))
 - Deprecated support for the `runtime.txt` file. ([#325](https://github.com/heroku/buildpacks-python/pull/325))
 - Improved the error messages shown when the `.python-version` file contents aren't valid. ([#325](https://github.com/heroku/buildpacks-python/pull/325))
 

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -25,8 +25,8 @@ pub(crate) const NEXT_UNRELEASED_PYTHON_3_MINOR_VERSION: u16 =
 pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 21);
 pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 16);
 pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 11);
-pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 8);
-pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 1);
+pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 9);
+pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 2);
 
 /// The Python version that was requested for a project.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2025/02/python-3132-and-3129-now-available.html

Changelog:
https://docs.python.org/3.13/whatsnew/changelog.html#python-3-13-2-final
https://docs.python.org/3.12/whatsnew/changelog.html#python-3-12-9-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/13146826968
https://github.com/heroku/heroku-buildpack-python/actions/runs/13146829096

GUS-W-17476921.
GUS-W-17476932.