### PR TITLE
Update to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "python-buildpack"
-edition = "2021"
-rust-version = "1.84"
+edition = "2024"
+rust-version = "1.85"
 # Disable automatic integration test discovery, since we import them in main.rs (see comment there).
 autotests = false
 

--- a/src/django.rs
+++ b/src/django.rs
@@ -97,10 +97,10 @@ mod tests {
 
     #[test]
     fn has_management_script_django_project() {
-        assert!(has_management_script(Path::new(
-            "tests/fixtures/django_staticfiles_latest_django"
-        ))
-        .unwrap());
+        assert!(
+            has_management_script(Path::new("tests/fixtures/django_staticfiles_latest_django"))
+                .unwrap()
+        );
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,4 @@
+use crate::BuildpackError;
 use crate::checks::ChecksError;
 use crate::django::DjangoCollectstaticError;
 use crate::layers::pip::PipLayerError;
@@ -7,14 +8,13 @@ use crate::layers::poetry_dependencies::PoetryDependenciesLayerError;
 use crate::layers::python::PythonLayerError;
 use crate::package_manager::DeterminePackageManagerError;
 use crate::python_version::{
-    RequestedPythonVersion, RequestedPythonVersionError, ResolvePythonVersionError,
     DEFAULT_PYTHON_VERSION, NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION,
-    OLDEST_SUPPORTED_PYTHON_3_MINOR_VERSION,
+    OLDEST_SUPPORTED_PYTHON_3_MINOR_VERSION, RequestedPythonVersion, RequestedPythonVersionError,
+    ResolvePythonVersionError,
 };
 use crate::python_version_file::ParsePythonVersionFileError;
 use crate::runtime_txt::ParseRuntimeTxtError;
 use crate::utils::{CapturedCommandError, DownloadUnpackArchiveError, StreamedCommandError};
-use crate::BuildpackError;
 use indoc::{formatdoc, indoc};
 use libherokubuildpack::log::log_error;
 use std::io;
@@ -45,7 +45,7 @@ pub(crate) fn on_error(error: libcnb::Error<BuildpackError>) {
                 Details: {libcnb_error}
             "},
         ),
-    };
+    }
 }
 
 fn on_buildpack_error(error: BuildpackError) {
@@ -62,7 +62,7 @@ fn on_buildpack_error(error: BuildpackError) {
         BuildpackError::PythonLayer(error) => on_python_layer_error(error),
         BuildpackError::RequestedPythonVersion(error) => on_requested_python_version_error(error),
         BuildpackError::ResolvePythonVersion(error) => on_resolve_python_version_error(error),
-    };
+    }
 }
 
 fn on_buildpack_detection_error(error: &io::Error) {
@@ -85,7 +85,7 @@ fn on_buildpack_checks_error(error: ChecksError) {
                 yourself, check that it wasn't set by an earlier buildpack.
             "},
         ),
-    };
+    }
 }
 
 fn on_determine_package_manager_error(error: DeterminePackageManagerError) {
@@ -137,7 +137,7 @@ fn on_determine_package_manager_error(error: DeterminePackageManagerError) {
                 no dependencies, then create an empty 'requirements.txt' file.
             "},
         ),
-    };
+    }
 }
 
 fn on_requested_python_version_error(error: RequestedPythonVersionError) {
@@ -240,7 +240,7 @@ fn on_requested_python_version_error(error: RequestedPythonVersionError) {
                 "},
             );
         }
-    };
+    }
 }
 
 fn on_resolve_python_version_error(error: ResolvePythonVersionError) {
@@ -335,7 +335,7 @@ fn on_python_layer_error(error: PythonLayerError) {
                 https://devcenter.heroku.com/articles/python-support#supported-runtimes
             "},
         ),
-    };
+    }
 }
 
 fn on_pip_layer_error(error: PipLayerError) {
@@ -367,7 +367,7 @@ fn on_pip_layer_error(error: PipLayerError) {
             "locating the pip wheel file bundled inside the Python 'ensurepip' module",
             &io_error,
         ),
-    };
+    }
 }
 
 fn on_pip_dependencies_layer_error(error: PipDependenciesLayerError) {
@@ -406,7 +406,7 @@ fn on_pip_dependencies_layer_error(error: PipDependenciesLayerError) {
                 "},
             ),
         },
-    };
+    }
 }
 
 fn on_poetry_layer_error(error: PoetryLayerError) {
@@ -438,7 +438,7 @@ fn on_poetry_layer_error(error: PoetryLayerError) {
             "locating the pip wheel file bundled inside the Python 'ensurepip' module",
             &io_error,
         ),
-    };
+    }
 }
 
 fn on_poetry_dependencies_layer_error(error: PoetryDependenciesLayerError) {
@@ -476,7 +476,7 @@ fn on_poetry_dependencies_layer_error(error: PoetryDependenciesLayerError) {
                 "},
             ),
         },
-    };
+    }
 }
 
 fn on_django_detection_error(error: &io::Error) {
@@ -546,7 +546,7 @@ fn on_django_collectstatic_error(error: DjangoCollectstaticError) {
                 "},
             ),
         },
-    };
+    }
 }
 
 fn log_io_error(header: &str, occurred_whilst: &str, io_error: &io::Error) {

--- a/src/layers/pip.rs
+++ b/src/layers/pip.rs
@@ -1,14 +1,14 @@
 use crate::packaging_tool_versions::PIP_VERSION;
 use crate::python_version::PythonVersion;
 use crate::utils::StreamedCommandError;
-use crate::{utils, BuildpackError, PythonBuildpack};
+use crate::{BuildpackError, PythonBuildpack, utils};
+use libcnb::Env;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::{
     CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerState, RestoredLayerAction,
 };
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use libcnb::Env;
 use libherokubuildpack::log::log_info;
 use serde::{Deserialize, Serialize};
 use std::io;

--- a/src/layers/pip_cache.rs
+++ b/src/layers/pip_cache.rs
@@ -1,13 +1,13 @@
 use crate::packaging_tool_versions::PIP_VERSION;
 use crate::python_version::PythonVersion;
 use crate::{BuildpackError, PythonBuildpack};
+use libcnb::Env;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::{
     CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerState, RestoredLayerAction,
 };
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use libcnb::Env;
 use libherokubuildpack::log::log_info;
 use serde::{Deserialize, Serialize};
 

--- a/src/layers/pip_dependencies.rs
+++ b/src/layers/pip_dependencies.rs
@@ -1,10 +1,10 @@
 use crate::utils::{self, StreamedCommandError};
 use crate::{BuildpackError, PythonBuildpack};
+use libcnb::Env;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::UncachedLayerDefinition;
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use libcnb::Env;
 use libherokubuildpack::log::log_info;
 use std::path::PathBuf;
 use std::process::Command;

--- a/src/layers/poetry.rs
+++ b/src/layers/poetry.rs
@@ -1,14 +1,14 @@
 use crate::packaging_tool_versions::POETRY_VERSION;
 use crate::python_version::PythonVersion;
 use crate::utils::StreamedCommandError;
-use crate::{utils, BuildpackError, PythonBuildpack};
+use crate::{BuildpackError, PythonBuildpack, utils};
+use libcnb::Env;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::{
     CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerState, RestoredLayerAction,
 };
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use libcnb::Env;
 use libherokubuildpack::log::log_info;
 use serde::{Deserialize, Serialize};
 use std::io;

--- a/src/layers/poetry_dependencies.rs
+++ b/src/layers/poetry_dependencies.rs
@@ -1,14 +1,14 @@
 use crate::packaging_tool_versions::POETRY_VERSION;
 use crate::python_version::PythonVersion;
 use crate::utils::StreamedCommandError;
-use crate::{utils, BuildpackError, PythonBuildpack};
+use crate::{BuildpackError, PythonBuildpack, utils};
+use libcnb::Env;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::{
     CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, RestoredLayerAction,
 };
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use libcnb::Env;
 use libherokubuildpack::log::log_info;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/src/layers/python.rs
+++ b/src/layers/python.rs
@@ -1,13 +1,13 @@
 use crate::python_version::PythonVersion;
 use crate::utils::{self, DownloadUnpackArchiveError};
 use crate::{BuildpackError, PythonBuildpack};
+use libcnb::Env;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::{
     CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerState, RestoredLayerAction,
 };
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use libcnb::Env;
 use libherokubuildpack::log::log_info;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -62,7 +62,7 @@ pub(crate) fn install_python(
                     log_info("Discarding cached Python since its layer metadata can't be parsed");
                 }
                 EmptyLayerCause::RestoredLayerAction {
-                    cause: (ref cached_python_version, reasons),
+                    cause: (cached_python_version, reasons),
                 } => {
                     // TODO: Move this type of detailed change messaging to a build config summary
                     // at the start of the build. This message could then be simplified to:

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use indoc::formatdoc;
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericMetadata, GenericPlatform};
-use libcnb::{buildpack_main, Buildpack, Env};
+use libcnb::{Buildpack, Env, buildpack_main};
 use libherokubuildpack::log::{log_header, log_info, log_warning};
 use std::io;
 
@@ -48,7 +48,9 @@ impl Buildpack for PythonBuildpack {
         {
             DetectResultBuilder::pass().build()
         } else {
-            log_info("No Python project files found (such as pyproject.toml, requirements.txt or poetry.lock).");
+            log_info(
+                "No Python project files found (such as pyproject.toml, requirements.txt or poetry.lock).",
+            );
             DetectResultBuilder::fail().build()
         }
     }

--- a/tests/checks_test.rs
+++ b/tests/checks_test.rs
@@ -1,6 +1,6 @@
 use crate::tests::default_build_config;
 use indoc::indoc;
-use libcnb_test::{assert_contains, PackResult, TestRunner};
+use libcnb_test::{PackResult, TestRunner, assert_contains};
 
 #[test]
 #[ignore = "integration test"]

--- a/tests/detect_test.rs
+++ b/tests/detect_test.rs
@@ -1,6 +1,6 @@
 use crate::tests::default_build_config;
 use indoc::indoc;
-use libcnb_test::{assert_contains, PackResult, TestRunner};
+use libcnb_test::{PackResult, TestRunner, assert_contains};
 
 #[test]
 #[ignore = "integration test"]

--- a/tests/django_test.rs
+++ b/tests/django_test.rs
@@ -1,6 +1,6 @@
 use crate::tests::default_build_config;
 use indoc::indoc;
-use libcnb_test::{assert_contains, assert_empty, PackResult, TestRunner};
+use libcnb_test::{PackResult, TestRunner, assert_contains, assert_empty};
 
 // This test uses symlinks for requirements.txt and manage.py to confirm that it's possible to use
 // them when the Django app is nested inside a subdirectory (such as in backend+frontend monorepos).

--- a/tests/package_manager_test.rs
+++ b/tests/package_manager_test.rs
@@ -1,6 +1,6 @@
 use crate::tests::default_build_config;
 use indoc::indoc;
-use libcnb_test::{assert_contains, PackResult, TestRunner};
+use libcnb_test::{PackResult, TestRunner, assert_contains};
 
 #[test]
 #[ignore = "integration test"]

--- a/tests/pip_test.rs
+++ b/tests/pip_test.rs
@@ -2,7 +2,7 @@ use crate::packaging_tool_versions::PIP_VERSION;
 use crate::python_version::{DEFAULT_PYTHON_FULL_VERSION, DEFAULT_PYTHON_VERSION};
 use crate::tests::default_build_config;
 use indoc::{formatdoc, indoc};
-use libcnb_test::{assert_contains, assert_empty, BuildpackReference, PackResult, TestRunner};
+use libcnb_test::{BuildpackReference, PackResult, TestRunner, assert_contains, assert_empty};
 
 #[test]
 #[ignore = "integration test"]

--- a/tests/poetry_test.rs
+++ b/tests/poetry_test.rs
@@ -2,7 +2,7 @@ use crate::packaging_tool_versions::POETRY_VERSION;
 use crate::python_version::{DEFAULT_PYTHON_FULL_VERSION, DEFAULT_PYTHON_VERSION};
 use crate::tests::default_build_config;
 use indoc::{formatdoc, indoc};
-use libcnb_test::{assert_contains, assert_empty, BuildpackReference, PackResult, TestRunner};
+use libcnb_test::{BuildpackReference, PackResult, TestRunner, assert_contains, assert_empty};
 
 #[test]
 #[ignore = "integration test"]

--- a/tests/python_version_test.rs
+++ b/tests/python_version_test.rs
@@ -1,11 +1,11 @@
 use crate::python_version::{
-    PythonVersion, DEFAULT_PYTHON_FULL_VERSION, DEFAULT_PYTHON_VERSION, LATEST_PYTHON_3_10,
-    LATEST_PYTHON_3_11, LATEST_PYTHON_3_12, LATEST_PYTHON_3_13, LATEST_PYTHON_3_9,
-    NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION,
+    DEFAULT_PYTHON_FULL_VERSION, DEFAULT_PYTHON_VERSION, LATEST_PYTHON_3_9, LATEST_PYTHON_3_10,
+    LATEST_PYTHON_3_11, LATEST_PYTHON_3_12, LATEST_PYTHON_3_13,
+    NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION, PythonVersion,
 };
 use crate::tests::default_build_config;
 use indoc::{formatdoc, indoc};
-use libcnb_test::{assert_contains, assert_empty, PackResult, TestRunner};
+use libcnb_test::{PackResult, TestRunner, assert_contains, assert_empty};
 
 #[test]
 #[ignore = "integration test"]


### PR DESCRIPTION
Updates to the Rust 2024 edition, which is now available as of Rust 1.85:

- https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html
- https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html
- https://doc.rust-lang.org/edition-guide/rust-2024/index.html

Fixes the one 2024 edition related compiler failure, applies the cargofmt style changes (via `cargo fmt`), and pre-emptively fixes some Cargo 1.86 clippy lint failures via `cargo clippy --fix` (seen since I run Rust beta locally).

GUS-W-17890888.