### PR TITLE
Set an explicit PR reviewer for CNB builder release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     with:
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
       dry_run: ${{ inputs.dry_run }}
+      reviewers: 'edmorley'
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
       cnb_registry_token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Currently for CNB releases, the PR opened against `cnb-builder-images` doesn't have an explicit reviewer set by the automation, which means it uses that repo's `CODEOWNERS` default of requesting review from the whole Languages team.

As of https://github.com/heroku/languages-github-actions/pull/289, the automation now supports passing a list of reviewers, which we can set for CNBs owned by a specific language owner.

This will help reduce review-request-spam to other team members.

GUS-W-18011095.