### PR TITLE
Stop using `--link` when running Django collectstatic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Stopped using `--link` when running Django's collectstatic command, since it doesn't work with remote storage backends. ([#339](https://github.com/heroku/buildpacks-python/pull/339))
+
 ## [0.24.2] - 2025-03-03
 
 ### Changed

--- a/src/django.rs
+++ b/src/django.rs
@@ -40,10 +40,10 @@ pub(crate) fn run_django_collectstatic(
     log_info("Running 'manage.py collectstatic'");
     utils::run_command_and_stream_output(
         Command::new("python")
+            // Note: We can't use `--link` since it doesn't work with remote storage backends (eg S3).
             .args([
                 MANAGEMENT_SCRIPT_NAME,
                 "collectstatic",
-                "--link",
                 // Using `--noinput` instead of `--no-input` since the latter requires Django 1.9+.
                 "--noinput",
             ])

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -529,7 +529,7 @@ fn on_django_collectstatic_error(error: DjangoCollectstaticError) {
             StreamedCommandError::NonZeroExitStatus(exit_status) => log_error(
                 "Unable to generate Django static files",
                 formatdoc! {"
-                    The 'python manage.py collectstatic --link --noinput' Django management
+                    The 'python manage.py collectstatic --noinput' Django management
                     command to generate static files failed ({exit_status}).
                     
                     This is most likely due an issue in your application code or Django

--- a/tests/django_test.rs
+++ b/tests/django_test.rs
@@ -19,7 +19,7 @@ fn django_staticfiles_latest_django() {
                     [Generating Django static files]
                     Running 'manage.py collectstatic'
                     
-                    1 static file symlinked to '/workspace/backend/staticfiles'.
+                    1 static file copied to '/workspace/backend/staticfiles'.
                 "}
             );
         },
@@ -40,9 +40,9 @@ fn django_staticfiles_legacy_django() {
                 indoc! {"
                     [Generating Django static files]
                     Running 'manage.py collectstatic'
-                    Linking '/workspace/testapp/static/robots.txt'
+                    Copying '/workspace/testapp/static/robots.txt'
                     
-                    1 static file symlinked to '/workspace/staticfiles'.
+                    1 static file copied to '/workspace/staticfiles'.
                 "}
             );
         },
@@ -148,7 +148,7 @@ fn django_staticfiles_misconfigured() {
                 context.pack_stderr,
                 indoc! {"
                     [Error: Unable to generate Django static files]
-                    The 'python manage.py collectstatic --link --noinput' Django management
+                    The 'python manage.py collectstatic --noinput' Django management
                     command to generate static files failed (exit status: 1).
                     
                     This is most likely due an issue in your application code or Django


### PR DESCRIPTION
Since:
- It causes collectstatic to fail if the app is using a Django remote storage backend (such as one that stores static assets on S3).
- Using `--link` provides little benefit to apps using local storage when using WhiteNoise configured with `WHITENOISE_KEEP_ONLY_HASHED_FILES=True` (as the Python Getting Started Guide does)

See:
- https://github.com/heroku/buildpacks-python/issues/328
- https://docs.djangoproject.com/en/5.1/ref/contrib/staticfiles/#collectstatic

Fixes #328.
GUS-W-17799386.