### PR TITLE
Add support for Python 3.13.3, 3.12.10, 3.11.12, 3.10.17 and 3.9.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Python 3.13 version alias now resolves to Python 3.13.3. ([#349](https://github.com/heroku/buildpacks-python/pull/349))
+- The Python 3.12 version alias now resolves to Python 3.12.10. ([#349](https://github.com/heroku/buildpacks-python/pull/349))
+- The Python 3.11 version alias now resolves to Python 3.11.12. ([#349](https://github.com/heroku/buildpacks-python/pull/349))
+- The Python 3.10 version alias now resolves to Python 3.10.17. ([#349](https://github.com/heroku/buildpacks-python/pull/349))
+- The Python 3.9 version alias now resolves to Python 3.9.22. ([#349](https://github.com/heroku/buildpacks-python/pull/349))
+
 ## [0.26.0] - 2025-04-08
 
 ### Changed

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -22,11 +22,11 @@ pub(crate) const NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION: u16 = 13;
 pub(crate) const NEXT_UNRELEASED_PYTHON_3_MINOR_VERSION: u16 =
     NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION + 1;
 
-pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 21);
-pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 16);
-pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 11);
-pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 9);
-pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 2);
+pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 22);
+pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 17);
+pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 12);
+pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 10);
+pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 3);
 
 /// The Python version that was requested for a project.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2025/04/python-3140a7-3133-31210-31112-31017.html

Changelogs:
https://docs.python.org/release/3.13.3/whatsnew/changelog.html#python-3-13-3-final
https://docs.python.org/release/3.12.10/whatsnew/changelog.html#python-3-12-10-final
https://docs.python.org/release/3.11.12/whatsnew/changelog.html#python-3-11-12-final
https://docs.python.org/release/3.10.17/whatsnew/changelog.html#python-3-10-17-final
https://docs.python.org/release/3.9.22/whatsnew/changelog.html#python-3-9-22-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/14341087204
https://github.com/heroku/heroku-buildpack-python/actions/runs/14341085641
https://github.com/heroku/heroku-buildpack-python/actions/runs/14341083031
https://github.com/heroku/heroku-buildpack-python/actions/runs/14341080059
https://github.com/heroku/heroku-buildpack-python/actions/runs/14344846015

GUS-W-17604326.
GUS-W-17604387.
GUS-W-18229141.