### PR TITLE
Add some more unit tests

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -34,7 +34,30 @@ pub(crate) fn check_environment(env: &Env) -> Result<(), ChecksError> {
 }
 
 /// Errors due to one of the environment checks failing.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum ChecksError {
     ForbiddenEnvVar(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_environment_valid() {
+        let mut env = Env::new();
+        env.insert("PYTHONPATH", "/example");
+        env.insert("PIP_EXTRA_INDEX_URL", "https://example.tld/simple");
+        assert_eq!(check_environment(&env), Ok(()));
+    }
+
+    #[test]
+    fn check_environment_invalid() {
+        let mut env = Env::new();
+        env.insert("PYTHONHOME", "/example");
+        assert_eq!(
+            check_environment(&env),
+            Err(ChecksError::ForbiddenEnvVar("PYTHONHOME".to_string()))
+        );
+    }
 }

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -189,6 +189,35 @@ mod tests {
     use super::*;
 
     #[test]
+    fn requested_python_version_display() {
+        assert_eq!(
+            RequestedPythonVersion {
+                major: 3,
+                minor: 13,
+                patch: None,
+                origin: PythonVersionOrigin::PythonVersionFile
+            }
+            .to_string(),
+            "3.13"
+        );
+        assert_eq!(
+            RequestedPythonVersion {
+                major: 3,
+                minor: 9,
+                patch: Some(0),
+                origin: PythonVersionOrigin::PythonVersionFile
+            }
+            .to_string(),
+            "3.9.0"
+        );
+    }
+
+    #[test]
+    fn python_version_display() {
+        assert_eq!(PythonVersion::new(3, 12, 0).to_string(), "3.12.0");
+    }
+
+    #[test]
     fn python_version_url() {
         assert_eq!(
             PythonVersion::new(3, 11, 0).url(&Target {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -159,4 +159,49 @@ mod tests {
     fn read_optional_file_io_error() {
         assert!(read_optional_file(Path::new("tests/fixtures/")).is_err());
     }
+
+    #[test]
+    fn run_command_and_stream_output_success() {
+        run_command_and_stream_output(Command::new("bash").args(["-c", "true"])).unwrap();
+    }
+
+    #[test]
+    fn run_command_and_stream_output_io_error() {
+        assert!(matches!(
+            run_command_and_stream_output(&mut Command::new("non-existent-command")).unwrap_err(),
+            StreamedCommandError::Io(_)
+        ));
+    }
+
+    #[test]
+    fn run_command_and_stream_output_non_zero_exit_status() {
+        assert!(matches!(
+            run_command_and_stream_output(Command::new("bash").args(["-c", "false"])).unwrap_err(),
+            StreamedCommandError::NonZeroExitStatus(_)
+        ));
+    }
+
+    #[test]
+    fn run_command_and_capture_output_success() {
+        let output =
+            run_command_and_capture_output(Command::new("bash").args(["-c", "echo output"]))
+                .unwrap();
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "output\n");
+    }
+
+    #[test]
+    fn run_command_and_capture_output_io_error() {
+        assert!(matches!(
+            run_command_and_capture_output(&mut Command::new("non-existent-command")).unwrap_err(),
+            CapturedCommandError::Io(_)
+        ));
+    }
+
+    #[test]
+    fn run_command_and_capture_output_non_zero_exit_status() {
+        assert!(matches!(
+            run_command_and_capture_output(Command::new("bash").args(["-c", "false"])).unwrap_err(),
+            CapturedCommandError::NonZeroExitStatus(_)
+        ));
+    }
 }


### PR DESCRIPTION
Adds unit tests for some cases that were previously only tested via integration tests.

Found by using `cargo-llvm-cov` and `cargo-mutants`:
https://github.com/taiki-e/cargo-llvm-cov
https://github.com/sourcefrog/cargo-mutants

GUS-W-18109300.