### PR TITLE
Improve error messages for invalid version in `.python-version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed support for the deprecated `runtime.txt` file. Python versions must now be specified using a `.python-version` file instead. ([#352](https://github.com/heroku/buildpacks-python/pull/352))
 
+### Changed
+
+- Improved the error messages shown when `.python-version` contains an invalid Python version. ([#353](https://github.com/heroku/buildpacks-python/pull/353))
+
 ## [0.26.1] - 2025-04-08
 
 ### Changed

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ impl Buildpack for PythonBuildpack {
             minor: 9,
             origin,
             ..
-        } = requested_python_version
+        } = &requested_python_version
         {
             log_warning(
                 "Support for Python 3.9 is deprecated",
@@ -115,7 +115,12 @@ impl Buildpack for PythonBuildpack {
         }
 
         log_header("Installing Python");
-        let python_layer_path = python::install_python(&context, &mut env, &python_version)?;
+        let python_layer_path = python::install_python(
+            &context,
+            &mut env,
+            &python_version,
+            &requested_python_version,
+        )?;
 
         let dependencies_layer_dir = match package_manager {
             PackageManager::Pip => {

--- a/tests/python_version_test.rs
+++ b/tests/python_version_test.rs
@@ -178,11 +178,11 @@ fn python_version_file_invalid_version() {
                 3.12.0invalid
                 
                 However, the Python version must be specified as either:
-                1. The major version only: 3.X  (recommended)
-                2. An exact patch version: 3.X.Y
+                1. The major version only, for example: {DEFAULT_PYTHON_VERSION} (recommended)
+                2. An exact patch version, for example: {DEFAULT_PYTHON_VERSION}.999
                 
-                Don't include quotes or a 'python-' prefix. Any code comments
-                must be on a separate line and be prefixed with '#'.
+                Don't include quotes, a 'python-' prefix or wildcards. Any
+                code comments must be on a separate line prefixed with '#'.
                 
                 For example, to request the latest version of Python {DEFAULT_PYTHON_VERSION},
                 update your .python-version file so it contains exactly:
@@ -244,7 +244,7 @@ fn python_version_file_no_version() {
                 version number. Don't include quotes or a 'python-' prefix.
                 
                 For example, to request the latest version of Python {DEFAULT_PYTHON_VERSION},
-                update your .python-version file so it contains:
+                update your .python-version file so it contains exactly:
                 {DEFAULT_PYTHON_VERSION}
             "}
         );
@@ -318,14 +318,24 @@ fn python_version_non_existent_minor() {
         assert_contains!(
             context.pack_stderr,
             &formatdoc! {"
-                [Error: The requested Python version wasn't found]
-                The requested Python version (3.12.999) wasn't found.
+                [Error: The requested Python version isn't available]
+                Your app's .python-version file specifies a Python version
+                of 3.12.999, however, we couldn't find that version on S3.
                 
-                Please switch to a supported Python version, or else don't specify a version
-                and the buildpack will use a default version (currently Python {DEFAULT_PYTHON_VERSION}).
+                Check that this Python version has been released upstream,
+                and that the Python buildpack has added support for it:
+                https://www.python.org/downloads/
+                https://github.com/heroku/buildpacks-python/blob/main/CHANGELOG.md
                 
-                For a list of the supported Python versions, see:
-                https://devcenter.heroku.com/articles/python-support#supported-runtimes
+                If it has, make sure that you are using the latest version
+                of this buildpack, and haven't pinned to an older release
+                via a custom buildpack configuration in project.toml.
+                
+                We also strongly recommend that you do not pin your app to an
+                exact Python version such as 3.12.999, and instead only specify
+                the major Python version of 3.12 in your .python-version file.
+                This will allow your app to receive the latest available Python
+                patch version automatically, and prevent this type of error.
             "}
         );
     });


### PR DESCRIPTION
This ports some of the recent error message improvements made in the classic Python buildpack to the CNB, plus some additional tweaks based on Honeycomb metrics for classic (which showed quite a bit of attempted usage of `.x` and `.*` style wildcards, which aren't valid syntax for the `.python-version` file).

GUS-W-18346802.