### PR TITLE
Improve error message when `.python-version` contains invisible characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improved the error messages shown when `.python-version` contains an invalid Python version. ([#353](https://github.com/heroku/buildpacks-python/pull/353))
+- Improved the error messages shown when `.python-version` contains an invalid Python version or stray invisible characters (such as ASCII control codes). ([#353](https://github.com/heroku/buildpacks-python/pull/353) and [#354](https://github.com/heroku/buildpacks-python/pull/354))
 
 ## [0.26.1] - 2025-04-08
 

--- a/tests/fixtures/python_version_file_invalid_version/.python-version
+++ b/tests/fixtures/python_version_file_invalid_version/.python-version
@@ -4,7 +4,8 @@
 # So are empty lines, and leading/trailing whitespace.
 
   
-  3.12.0invalid  
+  # The version number has a trailing control character.
+  3.12.0  
   
 
 # 2.7.18

--- a/tests/python_version_test.rs
+++ b/tests/python_version_test.rs
@@ -175,7 +175,7 @@ fn python_version_file_invalid_version() {
                 isn't in the correct format.
                 
                 The following version was found:
-                3.12.0invalid
+                3.12.0�
                 
                 However, the Python version must be specified as either:
                 1. The major version only, for example: {DEFAULT_PYTHON_VERSION} (recommended)


### PR DESCRIPTION
In Honeycomb metrics for the classic buildpack, there are a number of failures due to stray ASCII control codes or invisible Unicode characters being present before/after the version in `.python-version`. 

For example, I've seen the ASCII `ESC` control code (`U+001B`) and the Unicode zero width no-break space (`U+FEFF`).

Being invisible, these don't show up in the error message to users, which makes understanding and resolving the issue harder.

Now, such characters are replaced by the `�` symbol.

(I also checked the pyenv and uv `.python-version` parsing implementations, and they don't support these stray characters either.)

See also:
- https://ui.honeycomb.io/heroku/datasets/builds/board-query/DwMoerdz3jj/result/ovg8DxtftcC?vs=hideCompare
- https://www.ascii-code.com/
- https://invisible-characters.com/
- https://doc.rust-lang.org/std/primitive.str.html#method.replace
- https://doc.rust-lang.org/std/primitive.char.html#method.is_ascii
- https://doc.rust-lang.org/std/primitive.char.html#method.is_ascii_control
- https://github.com/pyenv/pyenv/blob/master/libexec/pyenv-version-file-read
- https://github.com/astral-sh/uv/blob/0.6.16/crates/uv-python/src/version_files.rs#L155-L180

GUS-W-18225365.