### PR TITLE
Improve the error messages for file I/O errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved the error messages shown when `.python-version` contains an invalid Python version or stray invisible characters (such as ASCII control codes). ([#353](https://github.com/heroku/buildpacks-python/pull/353) and [#354](https://github.com/heroku/buildpacks-python/pull/354))
+- Improved the error messages shown if I/O errors occur. ([#355](https://github.com/heroku/buildpacks-python/pull/355))
 
 ## [0.26.1] - 2025-04-08
 

--- a/src/layers/pip.rs
+++ b/src/layers/pip.rs
@@ -1,6 +1,6 @@
 use crate::packaging_tool_versions::PIP_VERSION;
 use crate::python_version::PythonVersion;
-use crate::utils::StreamedCommandError;
+use crate::utils::{FindBundledPipError, StreamedCommandError};
 use crate::{BuildpackError, PythonBuildpack, utils};
 use libcnb::Env;
 use libcnb::build::BuildContext;
@@ -11,7 +11,6 @@ use libcnb::layer::{
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use libherokubuildpack::log::log_info;
 use serde::{Deserialize, Serialize};
-use std::io;
 use std::path::Path;
 use std::process::Command;
 
@@ -133,7 +132,7 @@ struct PipLayerMetadata {
 #[derive(Debug)]
 pub(crate) enum PipLayerError {
     InstallPipCommand(StreamedCommandError),
-    LocateBundledPip(io::Error),
+    LocateBundledPip(FindBundledPipError),
 }
 
 impl From<PipLayerError> for libcnb::Error<BuildpackError> {

--- a/src/layers/poetry.rs
+++ b/src/layers/poetry.rs
@@ -1,6 +1,6 @@
 use crate::packaging_tool_versions::POETRY_VERSION;
 use crate::python_version::PythonVersion;
-use crate::utils::StreamedCommandError;
+use crate::utils::{FindBundledPipError, StreamedCommandError};
 use crate::{BuildpackError, PythonBuildpack, utils};
 use libcnb::Env;
 use libcnb::build::BuildContext;
@@ -11,7 +11,6 @@ use libcnb::layer::{
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use libherokubuildpack::log::log_info;
 use serde::{Deserialize, Serialize};
-use std::io;
 use std::path::Path;
 use std::process::Command;
 
@@ -134,7 +133,7 @@ struct PoetryLayerMetadata {
 #[derive(Debug)]
 pub(crate) enum PoetryLayerError {
     InstallPoetryCommand(StreamedCommandError),
-    LocateBundledPip(io::Error),
+    LocateBundledPip(FindBundledPipError),
 }
 
 impl From<PoetryLayerError> for libcnb::Error<BuildpackError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,13 +22,13 @@ use crate::python_version::{
     PythonVersionOrigin, RequestedPythonVersion, RequestedPythonVersionError,
     ResolvePythonVersionError,
 };
+use crate::utils::FileExistsError;
 use indoc::formatdoc;
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericMetadata, GenericPlatform};
 use libcnb::{Buildpack, Env, buildpack_main};
 use libherokubuildpack::log::{log_header, log_info, log_warning};
-use std::io;
 
 struct PythonBuildpack;
 
@@ -157,7 +157,7 @@ impl Buildpack for PythonBuildpack {
 #[derive(Debug)]
 pub(crate) enum BuildpackError {
     /// I/O errors when performing buildpack detection.
-    BuildpackDetection(io::Error),
+    BuildpackDetection(FileExistsError),
     /// Errors due to one of the environment checks failing.
     Checks(ChecksError),
     /// Errors determining which Python package manager to use for a project.
@@ -165,7 +165,7 @@ pub(crate) enum BuildpackError {
     /// Errors running the Django collectstatic command.
     DjangoCollectstatic(DjangoCollectstaticError),
     /// I/O errors when detecting whether Django is installed.
-    DjangoDetection(io::Error),
+    DjangoDetection(FileExistsError),
     /// Errors installing the project's dependencies into a layer using pip.
     PipDependenciesLayer(PipDependenciesLayerError),
     /// Errors installing pip into a layer.

--- a/tests/python_version_test.rs
+++ b/tests/python_version_test.rs
@@ -152,9 +152,14 @@ fn python_version_file_io_error() {
             context.pack_stderr,
             indoc! {"
                 [Error: Unable to read .python-version]
-                An unexpected error occurred whilst reading the .python-version file.
-                
-                Details: I/O Error: stream did not contain valid UTF-8
+                An I/O error occurred while reading the file:
+                /workspace/.python-version
+
+                Details: stream did not contain valid UTF-8
+
+                Check the file's permissions and that it contains valid UTF-8.
+
+                Then try building again.
             "}
         );
     });


### PR DESCRIPTION
This improves the error messages shown for file related I/O errors, by:
- ensuring that the path is always included
- adding additional suggestions to the error based on the context (which is now known, since specialised types are used for each of the common scenarios like checking if a file exists or reading a file to a string)

We're able to make the errors richer than those provided by `fs-err`, since we know the context in which the errors have occurred. 

For example, in the error message for `ReadOptionalFileError`s we know not to say to check for a missing file or that the file is a directory, since `read_optional_file()` explicitly excludes those cases by design. If we used `io::Error` (or `fs-err`'s equivalent) we would have to rely on the user not using the wrong logging function for the wrong I/O error case, rather than relying on the type system to do that for us.

These changes leave `log_io_error()` as being used only for the `Command` I/O cases. A later PR will switch adjust those usages too (but this PR is already large enough).

Closes #270.
GUS-W-12650236.