### PR TITLE
Improve the error messages for command I/O errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved the error messages shown when `.python-version` contains an invalid Python version or stray invisible characters (such as ASCII control codes). ([#353](https://github.com/heroku/buildpacks-python/pull/353) and [#354](https://github.com/heroku/buildpacks-python/pull/354))
-- Improved the error messages shown if I/O errors occur. ([#355](https://github.com/heroku/buildpacks-python/pull/355))
+- Improved the error messages shown if I/O errors occur. ([#355](https://github.com/heroku/buildpacks-python/pull/355) and [#356](https://github.com/heroku/buildpacks-python/pull/356))
 
 ## [0.26.1] - 2025-04-08
 


### PR DESCRIPTION
Similar to #355 but for I/O errors from spawning a `Command` instead of from file operations.

Such Command I/O errors are only likely to happen in the case of a bug, so the error message now says as much. The error also now generates the program name from the command, so avoid it getting out of sync. The command's args are intentionally omitted, since they aren't relevant for errors that occur when spawning a command. (ie: For command not found, it's the program that's not found, not the args.)

GUS-W-12650236.