### PR TITLE
Remove support for Ubuntu 20.04 / Heroku-20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["builder:24", "builder:22", "builder:20"]
+        builder: ["builder:24", "builder:22"]
         arch: ["amd64", "arm64"]
         exclude:
           - builder: "builder:22"
-            arch: "arm64"
-          - builder: "builder:20"
             arch: "arm64"
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed support for the deprecated `runtime.txt` file. Python versions must now be specified using a `.python-version` file instead. ([#352](https://github.com/heroku/buildpacks-python/pull/352))
+- Removed support for Ubuntu 20.04 (and thus Heroku-20 / `heroku/builder:20`). ([#358](https://github.com/heroku/buildpacks-python/pull/358))
 
 ### Changed
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -17,10 +17,6 @@ arch = "amd64"
 
 [[targets.distros]]
 name = "ubuntu"
-version = "20.04"
-
-[[targets.distros]]
-name = "ubuntu"
 version = "22.04"
 
 [[targets.distros]]


### PR DESCRIPTION
Since Heroku-20 is has reached end-of-life:
https://devcenter.heroku.com/changelog-items/3230

(When this is released, I'll edit the cnb-builder-images PR by hand so it only updates the newer builders, until such time as more CNBs drop support, then we can adjust the builders list used by the release automation to no longer update the manifest for `heroku/builder:20`)

GUS-W-14707057.