### PR TITLE
Add support for Python 3.13.4, 3.12.11, 3.11.13, 3.10.18 and 3.9.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The Python 3.13 version alias now resolves to Python 3.13.4. ([#374](https://github.com/heroku/buildpacks-python/pull/374))
+- The Python 3.12 version alias now resolves to Python 3.12.11. ([#374](https://github.com/heroku/buildpacks-python/pull/374))
+- The Python 3.11 version alias now resolves to Python 3.11.13. ([#374](https://github.com/heroku/buildpacks-python/pull/374))
+- The Python 3.10 version alias now resolves to Python 3.10.18. ([#374](https://github.com/heroku/buildpacks-python/pull/374))
+- The Python 3.9 version alias now resolves to Python 3.9.23. ([#374](https://github.com/heroku/buildpacks-python/pull/374))
 - Updated uv from 0.7.6 to 0.7.10. ([#375](https://github.com/heroku/buildpacks-python/pull/375))
 
 ## [2.1.0] - 2025-05-20

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -21,11 +21,11 @@ pub(crate) const NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION: u16 = 13;
 pub(crate) const NEXT_UNRELEASED_PYTHON_3_MINOR_VERSION: u16 =
     NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION + 1;
 
-pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 22);
-pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 17);
-pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 12);
-pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 10);
-pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 3);
+pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 23);
+pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 18);
+pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 13);
+pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 11);
+pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 4);
 
 /// The Python version that was requested for a project.
 #[derive(Clone, Debug, PartialEq)]

--- a/tests/uv_test.rs
+++ b/tests/uv_test.rs
@@ -217,12 +217,7 @@ fn uv_editable_git_compiled() {
                 Creating virtual environment
                 Running 'uv sync --locked --no-default-groups'
                 Resolved 2 packages in .+ms
-                   Building uv-editable-git-compiled @ file:///workspace
-                   Updating https://github.com/pypa/wheel.git \\(0.44.0\\)
-                      Built uv-editable-git-compiled @ file:///workspace
-                    Updated https://github.com/pypa/wheel.git \\(7bb46d7727e6e89fe56b3c78297b3af2672bbbe2\\)
-                   Building extension-dist @ git\\+https://github.com/pypa/wheel.git@7bb46d7727e6e89fe56b3c78297b3af2672bbbe2#subdirectory=tests/testdata/extension.dist
-                      Built extension-dist @ git\\+https://github.com/pypa/wheel.git@7bb46d7727e6e89fe56b3c78297b3af2672bbbe2#subdirectory=tests/testdata/extension.dist
+                   (?s:.)+
                 Prepared 2 packages in .+s
                 Installed 2 packages in .+s
                 Bytecode compiled 0 files in .+s

--- a/tests/uv_test.rs
+++ b/tests/uv_test.rs
@@ -60,7 +60,7 @@ fn uv_basic_install_and_cache_reuse() {
                  '/layers/heroku_python/venv/lib/python3.13/site-packages'\\]
                 
                 uv {UV_VERSION}
-                Using Python 3.13.3 environment at: /layers/heroku_python/venv
+                Using Python {DEFAULT_PYTHON_FULL_VERSION} environment at: /layers/heroku_python/venv
                 Package           Version
                 ----------------- -------
                 typing-extensions 4.13.2
@@ -175,7 +175,9 @@ fn uv_cache_previous_buildpack_version() {
                     Using Python version {DEFAULT_PYTHON_VERSION} specified in .python-version
                     
                     \\[Installing Python\\]
-                    Using cached Python 3.13.3
+                    Discarding cached Python 3.13.3 since:
+                     - The Python version has changed from 3.13.3 to {DEFAULT_PYTHON_FULL_VERSION}
+                    Installing Python {DEFAULT_PYTHON_FULL_VERSION}
                     
                     \\[Installing uv\\]
                     Discarding cached uv 0.7.3


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2025/06/python-3134-31211-31113-31018-and-3923.html

Changelogs:
https://docs.python.org/release/3.13.4/whatsnew/changelog.html#python-3-13-4-final
https://docs.python.org/release/3.12.11/whatsnew/changelog.html#python-3-12-11-final
https://docs.python.org/release/3.11.12/whatsnew/changelog.html#python-3-11-12-final
https://docs.python.org/release/3.10.18/whatsnew/changelog.html#python-3-10-18-final
https://docs.python.org/release/3.9.23/whatsnew/changelog.html#python-3-9-23-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/15427510896
https://github.com/heroku/heroku-buildpack-python/actions/runs/15427507963
https://github.com/heroku/heroku-buildpack-python/actions/runs/15427504571
https://github.com/heroku/heroku-buildpack-python/actions/runs/15427485959
https://github.com/heroku/heroku-buildpack-python/actions/runs/15427448283


GUS-W-17604345.
GUS-W-18699918.