### PR TITLE
Further reduce team review request noise from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,5 @@ buildpack.toml @edmorley
 CHANGELOG.md @edmorley
 Cargo.toml @edmorley
 Cargo.lock @edmorley
+/.github/workflows/ @edmorley
 /requirements/ @edmorley


### PR DESCRIPTION
We already request language owner review for various automation and Dependabot related PRs, to reduce the amount of review request notification noise sent to the language owner team alias.

This adds the GitHub Actions workflow directory to this list too, so that Dependabot PRs that bump the Actions versions are treated the same as the language-specific Dependabot PRs.

GUS-W-18951033.