### PR TITLE
Update test assertions after lifecycle output change

### DIFF
--- a/tests/checks_test.rs
+++ b/tests/checks_test.rs
@@ -11,7 +11,7 @@ fn checks_reject_pythonhome_env_var() {
 
     TestRunner::default().build(config, |context| {
         assert_contains!(
-            context.pack_stderr,
+            context.pack_stdout,
             indoc! {"
                 [Error: Unsafe environment variable found]
                 The environment variable 'PYTHONHOME' is set, however, it can
@@ -19,6 +19,8 @@ fn checks_reject_pythonhome_env_var() {
 
                 You must unset that environment variable. If you didn't set it
                 yourself, check that it wasn't set by an earlier buildpack.
+
+                ERROR: failed to build: exit status 1
             "}
         );
     });

--- a/tests/django_test.rs
+++ b/tests/django_test.rs
@@ -34,7 +34,7 @@ fn django_staticfiles_legacy_django() {
     TestRunner::default().build(
         default_build_config("tests/fixtures/django_staticfiles_legacy_django"),
         |context| {
-            // We can't `assert_empty!(context.pack_stderr)` here, due to the Python 3.9 deprecation warning.
+            assert_empty!(context.pack_stderr);
             assert_contains!(
                 context.pack_stdout,
                 indoc! {"
@@ -99,11 +99,7 @@ fn django_invalid_settings_module() {
                 context.pack_stdout,
                 indoc! {"
                     [Generating Django static files]
-                "}
-            );
-            assert_contains!(
-                context.pack_stderr,
-                indoc! {"
+
                     [Error: Unable to inspect Django configuration]
                     The 'python manage.py help collectstatic' Django management command
                     (used to check whether Django's static files feature is enabled)
@@ -116,7 +112,7 @@ fn django_invalid_settings_module() {
             );
             // Full traceback omitted since it will change across Django/Python versions causing test churn.
             assert_contains!(
-                context.pack_stderr,
+                context.pack_stdout,
                 indoc! {"
                     ModuleNotFoundError: No module named 'nonexistent-module'
                     
@@ -124,6 +120,8 @@ fn django_invalid_settings_module() {
                     This indicates there is a problem with your application code or Django
                     configuration. Try running the 'manage.py' script locally to see if the
                     same error occurs.
+
+                    ERROR: failed to build: exit status 1
                 "}
             );
         },
@@ -142,11 +140,15 @@ fn django_staticfiles_misconfigured() {
                 indoc! {"
                     [Generating Django static files]
                     Running 'manage.py collectstatic'
+                    Traceback (most recent call last):
                 "}
             );
+            // Full traceback omitted since it will change across Django/Python versions causing test churn.
             assert_contains!(
-                context.pack_stderr,
+                context.pack_stdout,
                 indoc! {"
+                    django.core.exceptions.ImproperlyConfigured: You're using the staticfiles app without having set the required STATIC_URL setting.
+
                     [Error: Unable to generate Django static files]
                     The 'python manage.py collectstatic --noinput' Django management
                     command to generate static files failed (exit status: 1).
@@ -162,6 +164,8 @@ fn django_staticfiles_misconfigured() {
                     Or, if you do not need to use static files in your app, disable the
                     Django static files feature by removing 'django.contrib.staticfiles'
                     from 'INSTALLED_APPS' in your app's Django configuration.
+
+                    ERROR: failed to build: exit status 1
                 "}
             );
         },

--- a/tests/package_manager_test.rs
+++ b/tests/package_manager_test.rs
@@ -10,7 +10,7 @@ fn no_package_manager_detected() {
             .expected_pack_result(PackResult::Failure),
         |context| {
             assert_contains!(
-                context.pack_stderr,
+                context.pack_stdout,
                 indoc! {"
                     [Error: Couldn't find any supported Python package manager files]
                     Your app must have either a 'requirements.txt', 'poetry.lock'
@@ -36,6 +36,8 @@ fn no_package_manager_detected() {
                     For help with using Python on Heroku, see:
                     https://devcenter.heroku.com/articles/getting-started-with-python-fir
                     https://devcenter.heroku.com/articles/python-support
+
+                    ERROR: failed to build: exit status 1
                 "}
             );
         },
@@ -50,7 +52,7 @@ fn multiple_package_managers_detected() {
             .expected_pack_result(PackResult::Failure),
         |context| {
             assert_contains!(
-                context.pack_stderr,
+                context.pack_stdout,
                 indoc! {"
                     [Error: Multiple Python package manager files were found]
                     Exactly one package manager file must be present in your app's
@@ -67,6 +69,8 @@ fn multiple_package_managers_detected() {
                     trying uv, since it supports lockfiles, is extremely fast, and
                     is actively maintained by a full-time team:
                     https://docs.astral.sh/uv/
+
+                    ERROR: failed to build: exit status 1
                 "}
             );
         },


### PR DESCRIPTION
`lifecycle` now emits all buildpack output to stdout in order to fix this stdout/stderr output interleaving bug:
https://github.com/buildpacks/pack/issues/2330
https://github.com/buildpacks/lifecycle/pull/1525

As such, the `libcnb-test` integration test assertions need updating to use stdout in a number of places.

This also allows the test assertions to correctly assert the placement of warning in-between other non-warning
content. (And in the process has revealed a couple of places where white-space could be tweaked, which will be handled separately as part of the future build output style change work).

See also:
https://github.com/heroku/cnb-builder-images/pull/784#issuecomment-3188677609

GUS-W-19337364.