### PR TITLE
Add support for Python 3.13.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Python 3.13 version alias now resolves to Python 3.13.7. ([#409](https://github.com/heroku/buildpacks-python/pull/409))
+
 ## [2.4.2] - 2025-08-13
 
 ### Changed

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -25,7 +25,7 @@ pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 23)
 pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 18);
 pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 13);
 pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 11);
-pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 6);
+pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 7);
 
 /// The Python version that was requested for a project.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2025/08/python-3140rc2-and-3137-are-go.html

Changelog:
https://docs.python.org/release/3.13.7/whatsnew/changelog.html#python-3-13-7-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/16984434876

GUS-W-19343647.