### PR TITLE
Use `pip install --isolated` when bootstrapping pip/Poetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the `pip install` commands used to install the pip and Poetry package managers to now use `--isolated` mode. ([#434](https://github.com/heroku/buildpacks-python/pull/434))
+
 ## [2.5.1] - 2025-09-23
 
 ### Changed

--- a/src/layers/pip.rs
+++ b/src/layers/pip.rs
@@ -94,6 +94,10 @@ pub(crate) fn install_pip(
                     .args([
                         &bundled_pip_module_path.to_string_lossy(),
                         "install",
+                        // Don't load any user-supplied pip configuration (pip.conf and `PIP_` env vars) given
+                        // that this is an internal step for installing pip (rather than app dependencies), and
+                        // so (a) doesn't need custom config, (b) we don't want the user to be able to break it.
+                        "--isolated",
                         // There is no point using pip's cache here, since the layer itself will be cached.
                         "--no-cache-dir",
                         "--no-input",

--- a/src/layers/poetry.rs
+++ b/src/layers/poetry.rs
@@ -92,6 +92,10 @@ pub(crate) fn install_poetry(
                         "install",
                         // Setting this via CLI args since for Poetry we aren't setting `PIP_DISABLE_PIP_VERSION_CHECK`.
                         "--disable-pip-version-check",
+                        // Don't load any user-supplied pip configuration (pip.conf and `PIP_` env vars) given
+                        // that this is an internal step for installing Poetry (rather than app dependencies), and
+                        // so (a) doesn't need custom config, (b) we don't want the user to be able to break it.
+                        "--isolated",
                         // There is no point using pip's cache here, since the layer itself will be cached.
                         "--no-cache-dir",
                         "--no-input",


### PR DESCRIPTION
So that any invalid global pip config (set via either `PIP_*` env vars or global `pip.conf` config files in the HOME directory) don't affect/break the bootstrapping of the package managers.

(Such config is still loaded during the later `pip install` used to install the app's own dependencies; this change only affects the internal buildpack bootstrapping stage.)

We don't have to update the uv installation step, since that doesn't use pip, since uv is a Rust binary installed from GitHub Releases.

This is the CNB equivalent of:
https://github.com/heroku/heroku-buildpack-python/pull/1915

See:
- https://pip.pypa.io/en/stable/cli/pip/#cmdoption-isolated
- https://pip.pypa.io/en/stable/topics/configuration/

GUS-W-19770487.