### PR TITLE
Further expand buildpack detection known file list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed the `pip install` commands used to install the pip and Poetry package managers to now use `--isolated` mode. ([#434](https://github.com/heroku/buildpacks-python/pull/434))
+- Added more Python project related file and directory names to the list recognised by buildpack detection. ([#435](https://github.com/heroku/buildpacks-python/pull/435))
 
 ## [2.5.1] - 2025-09-23
 

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 /// This list is deliberately larger than just the list of supported package manager files,
 /// so that Python projects that are missing some of the required files still pass detection,
 /// allowing us to show a helpful error message during the build phase.
-const KNOWN_PYTHON_PROJECT_FILES: [&str; 23] = [
+const KNOWN_PYTHON_PROJECT_FILES: [&str; 26] = [
     ".python-version",
     "__init__.py",
     "app.py",
@@ -26,14 +26,17 @@ const KNOWN_PYTHON_PROJECT_FILES: [&str; 23] = [
     "uv.lock",
     // Commonly seen misspellings of requirements.txt. (Which occur since pip doesn't
     // create/manage requirements files itself, so the filenames are manually typed.)
+    "requeriments.txt",
     "requirement.txt",
-    "Requirements.txt",
+    "requirements",
     "requirements.text",
+    "Requirements.txt",
     "requirements.txt.txt",
     "requirments.txt",
-    // Whilst virtual environments shouldn't be committed to Git (and so shouldn't
-    // normally be present during the build), they are often present for beginner
+    // Whilst cached pycs and virtual environments shouldn't be committed to Git (and so
+    // shouldn't normally be present during the build), they are often present for beginner
     // Python apps that are missing all of the other Python related files above.
+    "__pycache__/",
     ".venv/",
     "venv/",
 ];


### PR DESCRIPTION
Similar to #312, this adds more files to the buildpack's detection list - based on files commonly seen for apps that fail detection due to eg misspelled files.

This is the CNB equivalent of:
https://github.com/heroku/heroku-buildpack-python/pull/1914

GUS-W-19769734.