### PR TITLE
Add support for Python 3.13.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for Python 3.14. ([#439](https://github.com/heroku/buildpacks-python/pull/439))
 
+### Changed
+
+- The Python 3.13 version alias now resolves to Python 3.13.8. ([#440](https://github.com/heroku/buildpacks-python/pull/440))
+
 ## [2.6.0] - 2025-10-05
 
 ### Changed

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -25,7 +25,7 @@ pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 23)
 pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 18);
 pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 13);
 pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 11);
-pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 7);
+pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 8);
 pub(crate) const LATEST_PYTHON_3_14: PythonVersion = PythonVersion::new(3, 14, 0);
 
 /// The Python version that was requested for a project.


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2025/10/python-3138-is-now-available.html

Changelog:
https://docs.python.org/release/3.13.8/whatsnew/changelog.html#python-3-13-8

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/18379072906

GUS-W-17604367.