### PR TITLE
Add support for Python 3.12.12, 3.11.14, 3.10.19, 3.9.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The Python 3.13 version alias now resolves to Python 3.13.8. ([#440](https://github.com/heroku/buildpacks-python/pull/440))
+- The Python 3.12 version alias now resolves to Python 3.12.12. ([#441](https://github.com/heroku/buildpacks-python/pull/441))
+- The Python 3.11 version alias now resolves to Python 3.11.14. ([#441](https://github.com/heroku/buildpacks-python/pull/441))
+- The Python 3.10 version alias now resolves to Python 3.10.19. ([#441](https://github.com/heroku/buildpacks-python/pull/441))
+- The Python 3.9 version alias now resolves to Python 3.9.24. ([#441](https://github.com/heroku/buildpacks-python/pull/441))
 
 ## [2.6.0] - 2025-10-05
 

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -21,10 +21,10 @@ pub(crate) const NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION: u16 = 14;
 pub(crate) const NEXT_UNRELEASED_PYTHON_3_MINOR_VERSION: u16 =
     NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION + 1;
 
-pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 23);
-pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 18);
-pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 13);
-pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 11);
+pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 24);
+pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 19);
+pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 14);
+pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 12);
 pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 8);
 pub(crate) const LATEST_PYTHON_3_14: PythonVersion = PythonVersion::new(3, 14, 0);
 


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2025/10/python-31212-31114-31019-and-3924-are.html

Changelogs:
https://docs.python.org/release/3.12.12/whatsnew/changelog.html#python-3-12-12-final
https://docs.python.org/release/3.11.14/whatsnew/changelog.html#python-3-11-14-final
https://docs.python.org/release/3.10.19/whatsnew/changelog.html#python-3-10-19-final
https://docs.python.org/release/3.9.24/whatsnew/changelog.html#python-3-9-24-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/18379078616
https://github.com/heroku/heroku-buildpack-python/actions/runs/18383971694
https://github.com/heroku/heroku-buildpack-python/actions/runs/18383611414
https://github.com/heroku/heroku-buildpack-python/actions/runs/18383614298

GUS-W-19859397.