### PR TITLE
Add support for Python 3.13.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Python 3.13 version alias now resolves to Python 3.13.9. ([#444](https://github.com/heroku/buildpacks-python/pull/444))
+
 ## [2.7.0] - 2025-10-09
 
 ### Added

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -25,7 +25,7 @@ pub(crate) const LATEST_PYTHON_3_9: PythonVersion = PythonVersion::new(3, 9, 24)
 pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 19);
 pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 14);
 pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 12);
-pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 8);
+pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 9);
 pub(crate) const LATEST_PYTHON_3_14: PythonVersion = PythonVersion::new(3, 14, 0);
 
 /// The Python version that was requested for a project.


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2025/10/python-3139-is-now-available.html

Changelog:
https://docs.python.org/release/3.13.9/whatsnew/changelog.html#python-3-13-9-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/18524770867

GUS-W-19897903.