### PR TITLE
Pin Poetry's `dulwich` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pinned `dulwich` version when using Poetry to work around an incompatibility with Python <3.9.2. ([#447](https://github.com/heroku/heroku-buildpack-python/pull/447))
+
 ## [2.7.1] - 2025-10-15
 
 ### Changed

--- a/src/layers/poetry.rs
+++ b/src/layers/poetry.rs
@@ -103,6 +103,9 @@ pub(crate) fn install_poetry(
                         "--quiet",
                         "--user",
                         format!("poetry=={POETRY_VERSION}").as_str(),
+                        // We pin to an older dulwich version to work around https://github.com/jelmer/dulwich/issues/1948
+                        // on Python 3.9.0/3.9.1. TODO: Remove this pin when we drop support for Python 3.9 in Jan 2026.
+                        "dulwich==0.24.5",
                     ])
                     .env_clear()
                     .envs(&layer_env.apply(Scope::Build, env)),


### PR DESCRIPTION
After the recent upstream `dulwich` 0.24.6 release, CI in this repo started failing in the test that runs Poetry with our oldest supported Python patch version (3.9.0).

eg:

```
[Installing Poetry]
Installing Poetry 2.2.1

[Installing dependencies using Poetry]
Creating virtual environment
Running 'poetry sync --only main'

unhashable type: 'list'

[Error: Unable to install dependencies using Poetry]
The 'poetry sync --only main' command to install the app's
dependencies failed (exit status: 1).

See the log output above for more information.

ERROR: failed to build: exit status 1
```

Investigation showed this only affects Python 3.9.0 and 3.9.1, which are multiple years behind the latest 3.9.x patch version (3.9.24).

For more details see the upstream issue I opened:
jelmer/dulwich#1948

Our options are either to drop support for 3.9.0 and 3.9.1 (and require use of Python 3.9.2+), or to pin the dulwich version.

Given we'll be dropping support for Python 3.9 in January 2026, for now we'll temporarily pin the dulwich version. (It's also possible the dulwich project might adjust it's `requires-python` and yank the 0.24.6 release, in which case we'll be able to remove the pin before then.)

GUS-W-20000287.