### PR TITLE
Disable man-db auto-update in GHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      # The dpkg man-db trigger is excessively slow on GHA runners, see e.g.:
+      # https://github.com/actions/runner-images/issues/10977
+      # https://github.com/actions/runner/issues/4030
+      # We disable it here so it does not fire at the end of the following apt-get install
+      - name: Disable man-db auto-update
+        run: sudo rm -f /var/lib/man-db/auto-update
       - name: Install musl-tools
         run: sudo apt-get install -y --no-install-recommends musl-tools
       - name: Update Rust toolchain


### PR DESCRIPTION
The dpkg man-db trigger is excessively slow on GHA runners, see e.g.:
- https://github.com/actions/runner-images/issues/10977
- https://github.com/actions/runner/issues/4030

We disable it so it does not fire at the end of an `apt-get install`. This can easily shave a minute or two off the execution time.

GUS-W-19995078