### PR TITLE
Fix typos in error messages and comments

### DIFF
--- a/src/django.rs
+++ b/src/django.rs
@@ -71,7 +71,7 @@ fn has_collectstatic_command(app_dir: &Path, env: &Env) -> Result<bool, Captured
     .map_or_else(
         |error| match error {
             // We need to differentiate between the command not existing (due to the staticfiles app
-            // not being installed) and the Django config or mange.py script being broken. Ideally
+            // not being installed) and the Django config or manage.py script being broken. Ideally
             // we'd inspect the output of `manage.py help --commands` but that command unhelpfully
             // exits zero even if the app's `DJANGO_SETTINGS_MODULE` wasn't a valid module.
             // Note: Django incorrectly outputs "Unknown command" if the Django config is invalid

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -235,7 +235,7 @@ fn on_requested_python_version_error(error: RequestedPythonVersionError) {
                 PackageManager::Uv => log_error(
                     "The runtime.txt file isn't supported",
                     formatdoc! {"
-                        The runtime.txt file can longer be used, since it has been
+                        The runtime.txt file can no longer be used, since it has been
                         replaced by the more widely supported .python-version file.
 
                         Please switch to a .python-version file instead:
@@ -254,7 +254,7 @@ fn on_requested_python_version_error(error: RequestedPythonVersionError) {
                 _ => log_error(
                     "The runtime.txt file isn't supported",
                     formatdoc! {"
-                        The runtime.txt file can longer be used, since it has been
+                        The runtime.txt file can no longer be used, since it has been
                         replaced by the more widely supported .python-version file.
                         
                         Please delete your runtime.txt file and create a new file named:
@@ -609,7 +609,7 @@ fn on_django_collectstatic_error(error: DjangoCollectstaticError) {
                     The 'python manage.py collectstatic --noinput' Django management
                     command to generate static files failed ({exit_status}).
                     
-                    This is most likely due an issue in your application code or Django
+                    This is most likely due to an issue in your application code or Django
                     configuration. See the log output above for more information.
                     
                     If you are using the WhiteNoise package to optimize the serving of static

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ impl Buildpack for PythonBuildpack {
         // We inherit the current process's env vars, since we want `PATH` and `HOME` from the OS
         // to be set (so that later commands can find tools like Git in the base image), along
         // with previous-buildpack or user-provided env vars (so that features like env vars in
-        // in requirements files work). We protect against broken user-provided env vars via the
+        // requirements files work). We protect against broken user-provided env vars via the
         // checks feature and making sure that buildpack env vars take precedence in layers envs.
         let mut env = Env::from_current();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -192,7 +192,7 @@ pub(crate) struct FindBundledPipError {
 }
 
 /// A helper for running an external process using [`Command`], that streams stdout/stderr
-/// to the user and checks that the exit status of the process was non-zero.
+/// to the user and checks that the exit status of the process was zero.
 pub(crate) fn run_command_and_stream_output(
     command: &mut Command,
 ) -> Result<(), StreamedCommandError> {
@@ -214,7 +214,7 @@ pub(crate) fn run_command_and_stream_output(
 }
 
 /// A helper for running an external process using [`Command`], that captures stdout/stderr
-/// and checks that the exit status of the process was non-zero.
+/// and checks that the exit status of the process was zero.
 pub(crate) fn run_command_and_capture_output(
     command: &mut Command,
 ) -> Result<Output, CapturedCommandError> {

--- a/tests/django_test.rs
+++ b/tests/django_test.rs
@@ -196,7 +196,7 @@ fn django_staticfiles_misconfigured() {
                     The 'python manage.py collectstatic --noinput' Django management
                     command to generate static files failed (exit status: 1).
                     
-                    This is most likely due an issue in your application code or Django
+                    This is most likely due to an issue in your application code or Django
                     configuration. See the log output above for more information.
                     
                     If you are using the WhiteNoise package to optimize the serving of static

--- a/tests/poetry_test.rs
+++ b/tests/poetry_test.rs
@@ -228,8 +228,8 @@ fn poetry_editable_git_compiled() {
 
 // This checks that the Poetry bootstrap works even with older bundled pip, and that our chosen
 // Poetry version also supports our oldest supported Python version. The fixture also includes
-// a `brotli` directory to the buildpack isn't affected by an `ensurepip` bug in older Python
-// versions: https://github.com/heroku/heroku-buildpack-python/issues/1697
+// a `brotli` directory to confirm the buildpack isn't affected by an `ensurepip` bug in older
+// Python versions: https://github.com/heroku/heroku-buildpack-python/issues/1697
 #[test]
 #[ignore = "integration test"]
 fn poetry_oldest_python() {

--- a/tests/python_version_test.rs
+++ b/tests/python_version_test.rs
@@ -399,7 +399,7 @@ fn runtime_txt() {
                 [Determining Python version]
 
                 [Error: The runtime.txt file isn't supported]
-                The runtime.txt file can longer be used, since it has been
+                The runtime.txt file can no longer be used, since it has been
                 replaced by the more widely supported .python-version file.
                 
                 Please delete your runtime.txt file and create a new file named:
@@ -440,7 +440,7 @@ fn runtime_txt_invalid_version() {
                 [Determining Python version]
 
                 [Error: The runtime.txt file isn't supported]
-                The runtime.txt file can longer be used, since it has been
+                The runtime.txt file can no longer be used, since it has been
                 replaced by the more widely supported .python-version file.
                 
                 Please delete your runtime.txt file and create a new file named:

--- a/tests/uv_test.rs
+++ b/tests/uv_test.rs
@@ -338,7 +338,7 @@ fn uv_runtime_txt() {
                 [Determining Python version]
 
                 [Error: The runtime.txt file isn't supported]
-                The runtime.txt file can longer be used, since it has been
+                The runtime.txt file can no longer be used, since it has been
                 replaced by the more widely supported .python-version file.
 
                 Please switch to a .python-version file instead:


### PR DESCRIPTION
- `s/can longer/can no longer/`
- `s/due an issue/due to an issue/`
- `s/mange.py/manage.py/`
etc

GUS-W-21930145.
