### PR TITLE
Simplify the Python layer's `restored_layer_action`

### DIFF
--- a/src/layers/python.rs
+++ b/src/layers/python.rs
@@ -36,15 +36,15 @@ pub(crate) fn install_python(
                 let cached_python_version = cached_metadata.python_version.clone();
                 let reasons = cache_invalidation_reasons(cached_metadata, &new_metadata);
                 if reasons.is_empty() {
-                    Ok((
+                    (
                         RestoredLayerAction::KeepLayer,
                         (cached_python_version, Vec::new()),
-                    ))
+                    )
                 } else {
-                    Ok((
+                    (
                         RestoredLayerAction::DeleteLayer,
                         (cached_python_version, reasons),
-                    ))
+                    )
                 }
             },
         },


### PR DESCRIPTION
Wrapping in a `Result` is redundant since the function is infallible and libcnb supports returning a tuple directly from `restored_layer_action()`.

GUS-W-21930145.