### PR TITLE
Use const slice references instead of const arrays

### DIFF
--- a/src/detect.rs
+++ b/src/detect.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 /// This list is deliberately larger than just the list of supported package manager files,
 /// so that Python projects that are missing some of the required files still pass detection,
 /// allowing us to show a helpful error message during the build phase.
-const KNOWN_PYTHON_PROJECT_FILES: [&str; 26] = [
+const KNOWN_PYTHON_PROJECT_FILES: &[&str] = &[
     ".python-version",
     "__init__.py",
     "app.py",

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -1,7 +1,7 @@
 use crate::{FileExistsError, utils};
 use std::path::Path;
 
-pub(crate) const SUPPORTED_PACKAGE_MANAGERS: [PackageManager; 3] = [
+pub(crate) const SUPPORTED_PACKAGE_MANAGERS: &[PackageManager] = &[
     PackageManager::Pip,
     PackageManager::Poetry,
     PackageManager::Uv,
@@ -38,8 +38,8 @@ pub(crate) fn determine_package_manager(
     app_dir: &Path,
 ) -> Result<PackageManager, DeterminePackageManagerError> {
     let package_managers_found = SUPPORTED_PACKAGE_MANAGERS
-        .into_iter()
-        .filter_map(|package_manager| {
+        .iter()
+        .filter_map(|&package_manager| {
             utils::file_exists(&app_dir.join(package_manager.packages_file()))
                 .map_err(DeterminePackageManagerError::CheckFileExists)
                 .map(|exists| exists.then_some(package_manager))


### PR DESCRIPTION
Using const slice references instead of a fixed size array avoids having to manually update the array length each time entries are added or removed.

GUS-W-21930145.