### PR TITLE
Fix broken links in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Pinned `dulwich` version when using Poetry to work around an incompatibility with Python <3.9.2. ([#447](https://github.com/heroku/heroku-buildpack-python/pull/447))
+- Pinned `dulwich` version when using Poetry to work around an incompatibility with Python <3.9.2. ([#447](https://github.com/heroku/buildpacks-python/pull/447))
 
 ## [2.7.1] - 2025-10-15
 
@@ -552,7 +552,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated pip from 23.2.1 to 23.3.1. ([#131](https://github.com/heroku/buildpacks-python/pull/131))
 - Updated wheel from 0.41.0 to 0.41.2. ([#100](https://github.com/heroku/buildpacks-python/pull/100))
-- Updated buildpack display name and description. ([#135](https://github.com/heroku/buildpack-python/pull/135))
+- Updated buildpack display name and description. ([#135](https://github.com/heroku/buildpacks-python/pull/135))
 
 ## [0.7.1] - 2023-10-02
 


### PR DESCRIPTION
One linking to the classic buildpack instead of the CNB, and the other omitting the `s` in the repo name.