### PR TITLE
Add support for Python 3.14.4 and 3.13.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The Python 3.14 version alias now resolves to Python 3.14.4. ([#548](https://github.com/heroku/buildpacks-python/pull/548))
+- The Python 3.13 version alias now resolves to Python 3.13.13. ([#548](https://github.com/heroku/buildpacks-python/pull/548))
 - The forbidden env vars check now reports all forbidden env vars found rather than only the first. ([#542](https://github.com/heroku/buildpacks-python/pull/542))
 - The forbidden env vars check now checks for known problematic Poetry env vars too. ([#542](https://github.com/heroku/buildpacks-python/pull/542))
 

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -24,8 +24,8 @@ pub(crate) const NEXT_UNRELEASED_PYTHON_3_MINOR_VERSION: u16 =
 pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 20);
 pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 15);
 pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 13);
-pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 12);
-pub(crate) const LATEST_PYTHON_3_14: PythonVersion = PythonVersion::new(3, 14, 3);
+pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 13);
+pub(crate) const LATEST_PYTHON_3_14: PythonVersion = PythonVersion::new(3, 14, 4);
 
 /// The Python version that was requested for a project.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2026/04/python-3150a8-3144-31313/

Changelogs:
https://docs.python.org/release/3.14.4/whatsnew/changelog.html#python-3-14-4-final
https://docs.python.org/release/3.13.13/whatsnew/changelog.html#python-3-13-13-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/24106929682
https://github.com/heroku/heroku-buildpack-python/actions/runs/24106935699

GUS-W-20590503.
GUS-W-20590550.