### PR TITLE
Add support for Ubuntu 26.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["builder:24", "builder:22"]
+        builder: ["builder:26", "builder:24", "builder:22"]
         arch: ["amd64", "arm64"]
         exclude:
           - builder: "builder:22"
@@ -86,6 +86,9 @@ jobs:
       # only those and not the unit tests, via the `--ignored` option. On the latest stack
       # we run all integration tests, but on older stacks we only run stack-specific tests.
       - name: Run integration tests (all tests)
+        # TODO: Switch to builder:26 once Ubuntu 26.04 is GA and also Python and package manager
+        # versions have changed, so that we have a suitable historic buildpack version that both
+        # supports the new stack, and has enough version changes for the cache invalidation tests.
         if: matrix.builder == 'builder:24'
         run: cargo test --locked -- --ignored --test-threads $(($(nproc)+1))
       - name: Run integration tests (stack-specific tests only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added support for Ubuntu 26.04 (and thus Heroku-26 / `heroku/builder:26`).
+- Added support for Ubuntu 26.04 (and thus Heroku-26 / `heroku/builder:26`). ([#550](https://github.com/heroku/buildpacks-python/pull/550))
 
 ## [6.3.0] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for Ubuntu 26.04 (and thus Heroku-26 / `heroku/builder:26`).
+
 ## [6.3.0] - 2026-04-07
 
 ### Changed

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -23,6 +23,10 @@ version = "22.04"
 name = "ubuntu"
 version = "24.04"
 
+[[targets.distros]]
+name = "ubuntu"
+version = "26.04"
+
 [[targets]]
 os = "linux"
 arch = "arm64"
@@ -30,6 +34,10 @@ arch = "arm64"
 [[targets.distros]]
 name = "ubuntu"
 version = "24.04"
+
+[[targets.distros]]
+name = "ubuntu"
+version = "26.04"
 
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-python" }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -16,6 +16,9 @@ use libcnb_test::BuildConfig;
 use std::env;
 use std::path::Path;
 
+// TODO: Switch to builder:26 once Ubuntu 26.04 is GA and also Python and package manager
+// versions have changed, so that we have a suitable historic buildpack version that both
+// supports the new stack, and has enough version changes for the cache invalidation tests.
 const DEFAULT_BUILDER: &str = "heroku/builder:24";
 
 fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
@@ -26,7 +29,9 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     // to allow configuring the target arch independently of the builder name (eg via env var).
     let target_triple = match builder.as_str() {
         // Compile the buildpack for ARM64 iff the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => {
+            "aarch64-unknown-linux-musl"
+        }
         _ => "x86_64-unknown-linux-musl",
     };
     config.target_triple(target_triple);


### PR DESCRIPTION
Adds support for Ubuntu 26.04 (and thus Heroku-26 / `heroku/builder:26`).

Note: Ubuntu 26.04 is not yet GA upstream, so we don't yet recommend using it in production. See:
https://documentation.ubuntu.com/release-notes/26.04/schedule/

This is the CNB equivalent of:
https://github.com/heroku/heroku-buildpack-python/pull/2073

GUS-W-20775619.