### PR TITLE
Group Python Dependabot PRs too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,9 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    groups:
+      # We don't limit grouping for Python to just minor/patch versions, since pip doesn't follow
+      # semver, plus having to update CHANGELOG.md means it's easier to just have a single PR.
+      python-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
To reduce the amount of PR rebasing that has to occur each month when we update the Python package manager versions, given that they need CHANGELOG.md entries each, which otherwise cause conflicts.

See:
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--

GUS-W-22400243.