### PR TITLE
Mention uv.lock in the detection failed error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Poetry from 2.3.4 to 2.4.0. ([#564](https://github.com/heroku/buildpacks-python/pull/564))
 - Updated uv from 0.11.6 to 0.11.11. ([#562](https://github.com/heroku/buildpacks-python/pull/562))
 - The forbidden env vars check now also rejects `POETRY_VIRTUALENVS_IN_PROJECT`. ([#566](https://github.com/heroku/buildpacks-python/pull/566))
+- Updated the wording of the message shown when buildpack detection fails to also mention `uv.lock`. ([#567](https://github.com/heroku/buildpacks-python/pull/567))
 
 ## [6.4.1] - 2026-04-13
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ impl Buildpack for PythonBuildpack {
             DetectResultBuilder::pass().build()
         } else {
             log_info(
-                "No Python project files found (such as pyproject.toml, requirements.txt or poetry.lock).",
+                "No supported Python package manager files found (such as requirements.txt, poetry.lock or uv.lock).",
             );
             DetectResultBuilder::fail().build()
         }

--- a/tests/detect_test.rs
+++ b/tests/detect_test.rs
@@ -11,7 +11,7 @@ fn detect_rejects_non_python_projects() {
             assert_contains!(
                 context.pack_stdout,
                 indoc! {"========
-                    No Python project files found (such as pyproject.toml, requirements.txt or poetry.lock).
+                    No supported Python package manager files found (such as requirements.txt, poetry.lock or uv.lock).
                     ======== Results ========
                 "}
             );


### PR DESCRIPTION
Since it's currently the only package manager file that wasn't explicitly mentioned in the message.

In the future this message will be expanded further (to more closely align with that used by the classic Python buildpack), but for now this is a quick win.

GUS-W-22400929.