### PR TITLE
Add support for Python 3.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Python 3.14 version alias now resolves to Python 3.14.5. ([#569](https://github.com/heroku/buildpacks-python/pull/569))
+
 ## [6.5.0] - 2026-05-07
 
 ### Changed

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -25,7 +25,7 @@ pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 2
 pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 15);
 pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 13);
 pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 13);
-pub(crate) const LATEST_PYTHON_3_14: PythonVersion = PythonVersion::new(3, 14, 4);
+pub(crate) const LATEST_PYTHON_3_14: PythonVersion = PythonVersion::new(3, 14, 5);
 
 /// The Python version that was requested for a project.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2026/05/python-3145-is-out/

Changelog:
https://docs.python.org/release/3.14.5/whatsnew/changelog.html#python-3-14-5-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/25693905266

GUS-W-22439828.