### PR TITLE
Auto-trigger release workflow on prepare-release PR merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,13 @@
 name: Release Buildpack
 
 on:
+  # Auto-trigger when the "Prepare release" PR (created by the
+  # _buildpacks-prepare-release.yml workflow) is merged.
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
   workflow_dispatch:
     inputs:
       dry_run:
@@ -14,10 +21,19 @@ permissions: {}
 jobs:
   release:
     name: Release
+    # On `pull_request`, only run for the merged auto-generated
+    # "Prepare release" PR (branch name set by
+    # _buildpacks-prepare-release.yml). Manual dispatches always run.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.pull_request.head.ref == 'prepare-release' &&
+       github.event.pull_request.user.login == 'heroku-linguist[bot]')
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release.yml@latest
     with:
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
-      dry_run: ${{ inputs.dry_run }}
+      dry_run: ${{ inputs.dry_run || false }}
       reviewers: 'edmorley'
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}


### PR DESCRIPTION
The "Prepare release" workflow already auto-merges its PR once CI passes. Hooking the release workflow to that merge removes the manual step of dispatching it afterwards.

Belt-and-suspenders `if:` filters reject fork PRs and non-Linguist authors, so only the auto-generated `prepare-release` PR can trigger a release. Manual `workflow_dispatch` is preserved for re-runs and dry-run testing.

Pattern documented in https://github.com/heroku/languages-github-actions/pull/358; first applied (and validated end-to-end) in https://github.com/heroku/buildpacks-dotnet/pull/425.