### PR TITLE
Update default builder to `heroku/builder:26`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,11 +86,8 @@ jobs:
       # only those and not the unit tests, via the `--ignored` option. On the latest stack
       # we run all integration tests, but on older stacks we only run stack-specific tests.
       - name: Run integration tests (all tests)
-        # TODO: Switch to builder:26 once Ubuntu 26.04 is GA and also Python and package manager
-        # versions have changed, so that we have a suitable historic buildpack version that both
-        # supports the new stack, and has enough version changes for the cache invalidation tests.
-        if: matrix.builder == 'builder:24'
+        if: matrix.builder == 'builder:26'
         run: cargo test --locked -- --ignored --test-threads $(($(nproc)+1))
       - name: Run integration tests (stack-specific tests only)
-        if: matrix.builder != 'builder:24'
+        if: matrix.builder != 'builder:26'
         run: cargo test --locked -- --ignored --test-threads $(($(nproc)+1)) 'python_version_test::'

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To build a Python application codebase into a production image:
 
 ```bash
 $ cd ~/workdir/sample-python-app
-$ pack build sample-app --builder heroku/builder:24
+$ pack build sample-app --builder heroku/builder:26
 ```
 
 Then run the image:

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -16,10 +16,7 @@ use libcnb_test::BuildConfig;
 use std::env;
 use std::path::Path;
 
-// TODO: Switch to builder:26 once Ubuntu 26.04 is GA and also Python and package manager
-// versions have changed, so that we have a suitable historic buildpack version that both
-// supports the new stack, and has enough version changes for the cache invalidation tests.
-const DEFAULT_BUILDER: &str = "heroku/builder:24";
+const DEFAULT_BUILDER: &str = "heroku/builder:26";
 
 fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     let builder = builder();

--- a/tests/pip_test.rs
+++ b/tests/pip_test.rs
@@ -164,7 +164,7 @@ fn pip_cache_invalidation_package_manager_changed() {
 fn pip_cache_previous_buildpack_version() {
     let mut config = default_build_config("tests/fixtures/pip_basic");
     config.buildpacks([BuildpackReference::Other(
-        "docker://docker.io/heroku/buildpack-python:0.16.0".to_string(),
+        "docker://docker.io/heroku/buildpack-python:6.4.0".to_string(),
     )]);
     let rebuild_config = default_build_config("tests/fixtures/pip_basic");
 
@@ -180,12 +180,12 @@ fn pip_cache_previous_buildpack_version() {
                     a '.python-version' file, containing a Python version like '{DEFAULT_PYTHON_VERSION}'.
                     
                     [Installing Python]
-                    Discarding cached Python 3.12.5 since:
-                     - The Python version has changed from 3.12.5 to {DEFAULT_PYTHON_FULL_VERSION}
+                    Discarding cached Python 3.14.4 since:
+                     - The Python version has changed from 3.14.4 to {DEFAULT_PYTHON_FULL_VERSION}
                     Installing Python {DEFAULT_PYTHON_FULL_VERSION}
                     
                     [Installing pip]
-                    Discarding cached pip 24.2
+                    Discarding cached pip 26.0.1
                     Installing pip {PIP_VERSION}
                     
                     [Installing dependencies using pip]

--- a/tests/poetry_test.rs
+++ b/tests/poetry_test.rs
@@ -153,7 +153,7 @@ fn poetry_cache_invalidation_package_manager_changed() {
 fn poetry_cache_previous_buildpack_version() {
     let mut config = default_build_config("tests/fixtures/poetry_basic");
     config.buildpacks([BuildpackReference::Other(
-        "docker://docker.io/heroku/buildpack-python:2.7.0".to_string(),
+        "docker://docker.io/heroku/buildpack-python:6.4.0".to_string(),
     )]);
     let rebuild_config = default_build_config("tests/fixtures/poetry_basic");
 
@@ -167,12 +167,12 @@ fn poetry_cache_previous_buildpack_version() {
                     Using Python version {DEFAULT_PYTHON_VERSION} specified in .python-version
                     
                     [Installing Python]
-                    Discarding cached Python 3.14.0 since:
-                     - The Python version has changed from 3.14.0 to {DEFAULT_PYTHON_FULL_VERSION}
+                    Discarding cached Python 3.14.4 since:
+                     - The Python version has changed from 3.14.4 to {DEFAULT_PYTHON_FULL_VERSION}
                     Installing Python {DEFAULT_PYTHON_FULL_VERSION}
                     
                     [Installing Poetry]
-                    Discarding cached Poetry 2.2.1
+                    Discarding cached Poetry 2.3.3
                     Installing Poetry {POETRY_VERSION}
                     
                     [Installing dependencies using Poetry]

--- a/tests/uv_test.rs
+++ b/tests/uv_test.rs
@@ -165,7 +165,7 @@ fn uv_cache_invalidation_package_manager_changed() {
 fn uv_cache_previous_buildpack_version() {
     let mut config = default_build_config("tests/fixtures/uv_basic");
     config.buildpacks([BuildpackReference::Other(
-        "docker://docker.io/heroku/buildpack-python:2.7.0".to_string(),
+        "docker://docker.io/heroku/buildpack-python:6.4.0".to_string(),
     )]);
     let rebuild_config = default_build_config("tests/fixtures/uv_basic");
 
@@ -179,12 +179,12 @@ fn uv_cache_previous_buildpack_version() {
                     Using Python version {DEFAULT_PYTHON_VERSION} specified in .python-version
                     
                     \\[Installing Python\\]
-                    Discarding cached Python 3.14.0 since:
-                     - The Python version has changed from 3.14.0 to {DEFAULT_PYTHON_FULL_VERSION}
+                    Discarding cached Python 3.14.4 since:
+                     - The Python version has changed from 3.14.4 to {DEFAULT_PYTHON_FULL_VERSION}
                     Installing Python {DEFAULT_PYTHON_FULL_VERSION}
                     
                     \\[Installing uv\\]
-                    Discarding cached uv 0.8.23
+                    Discarding cached uv 0.11.3
                     Installing uv {UV_VERSION}
                     
                     \\[Installing dependencies using uv\\]


### PR DESCRIPTION
Switches the default integration test builder and the README usage example from `heroku/builder:24` to `heroku/builder:26`. 

Also flips the CI integration test conditionals so all tests run against `:26` and only stack-specific tests run against older builders (doing this required updating the package manager tests to use a newer historic buildpack version so the initial build can run on the new builder). 

GUS-W-22580946.