### PR TITLE
Add support for Python 3.14.6 and 3.13.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Python 3.14 version alias now resolves to Python 3.14.6. ([#578](https://github.com/heroku/buildpacks-python/pull/578))
+- The Python 3.13 version alias now resolves to Python 3.13.14. ([#578](https://github.com/heroku/buildpacks-python/pull/578))
+
 ## [6.5.2] - 2026-06-04
 
 ### Changed

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -24,8 +24,8 @@ pub(crate) const NEXT_UNRELEASED_PYTHON_3_MINOR_VERSION: u16 =
 pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 20);
 pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 15);
 pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 13);
-pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 13);
-pub(crate) const LATEST_PYTHON_3_14: PythonVersion = PythonVersion::new(3, 14, 5);
+pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 14);
+pub(crate) const LATEST_PYTHON_3_14: PythonVersion = PythonVersion::new(3, 14, 6);
 
 /// The Python version that was requested for a project.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2026/06/python-3146-31314/

Changelogs:
https://docs.python.org/release/3.14.6/whatsnew/changelog.html#python-3-14-6-final
https://docs.python.org/release/3.13.14/whatsnew/changelog.html#python-3-13-14-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/27281631125
https://github.com/heroku/heroku-buildpack-python/actions/runs/27289906221

GUS-W-20590507.
GUS-W-20590552.