### PR TITLE
Explicitly enable the serde `derive` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ flate2 = { version = "1", default-features = false, features = ["zlib-rs"] }
 indoc = "2"
 libcnb = { version = "0.30", features = ["trace"] }
 libherokubuildpack = { version = "0.30", default-features = false, features = ["log"] }
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 tar = { version = "0.4", default-features = false }
 ureq = { version = "2", default-features = false, features = ["tls"] }
 zstd = { version = "0.13", default-features = false }


### PR DESCRIPTION
The buildpack uses serde's derive macros but `Cargo.toml` didn't enable the
`derive` feature; compilation only worked because libcnb happens to enable it
transitively.

Making this change in part to stop Claude reporting it when code
reviewing the repo for bugs/inconsistencies and other potential improvements.

GUS-W-23022354.
