### PR TITLE
Fix inconsistencies in error messages and comments

### DIFF
--- a/src/django.rs
+++ b/src/django.rs
@@ -42,7 +42,7 @@ pub(crate) fn run_django_collectstatic(
     log_info("Running 'manage.py collectstatic'");
     utils::run_command_and_stream_output(
         Command::new("python")
-            // Note: We can't use `--link` since it doesn't work with remote storage backends (eg S3).
+            // Note: We can't use `--link` since it doesn't work with remote storage backends (e.g. S3).
             .args([
                 MANAGEMENT_SCRIPT_NAME,
                 "collectstatic",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -367,7 +367,7 @@ fn on_python_layer_error(error: PythonLayerError) {
                     An I/O error occurred while unpacking the downloaded Python
                     runtime archive and writing it to disk.
                     
-                    Details: I/O Error: {io_error}
+                    Details: {io_error}
                 "},
             ),
         },
@@ -446,7 +446,7 @@ fn on_pip_dependencies_layer_error(error: PipDependenciesLayerError) {
         },
         PipDependenciesLayerError::PipInstallCommand(error) => match error {
             StreamedCommandError::Io(error) => log_command_io_error(error),
-            // TODO: Add more suggestions here as to causes (eg network, invalid requirements.txt,
+            // TODO: Add more suggestions here as to causes (e.g. network, invalid requirements.txt,
             // package broken or not compatible with version of Python, missing system dependencies etc)
             StreamedCommandError::NonZeroExitStatus(exit_status) => log_error(
                 "Unable to install dependencies using pip",
@@ -542,7 +542,7 @@ fn on_uv_layer_error(error: UvLayerError) {
                     An I/O error occurred while unpacking the downloaded uv
                     archive and writing it to disk.
                     
-                    Details: I/O Error: {io_error}
+                    Details: {io_error}
                 "},
             ),
         },
@@ -617,7 +617,7 @@ fn on_django_collectstatic_error(error: DjangoCollectstaticError) {
                     This is most likely due to an issue in your application code or Django
                     configuration. See the log output above for more information.
                     
-                    If you are using the WhiteNoise package to optimize the serving of static
+                    If you are using the WhiteNoise package to optimise the serving of static
                     files with Django (recommended), check that your app is using the Django
                     config options shown here:
                     https://whitenoise.readthedocs.io/en/stable/django.html

--- a/src/layers/pip_dependencies.rs
+++ b/src/layers/pip_dependencies.rs
@@ -15,7 +15,7 @@ use std::process::Command;
 // - We can't install into the system site-packages inside the main Python directory since
 //   we need the app dependencies to be in their own layer.
 // - Some packages are broken with `--user` installs when using relocated Python, and
-//   otherwise require other workarounds. eg: https://github.com/unbit/uwsgi/issues/2525
+//   otherwise require other workarounds. e.g.: https://github.com/unbit/uwsgi/issues/2525
 // - PEP-405 style venvs are very lightweight and are also much more frequently
 //   used in the wild compared to `--user`, and therefore the better tested path.
 //

--- a/src/layers/poetry_dependencies.rs
+++ b/src/layers/poetry_dependencies.rs
@@ -20,7 +20,7 @@ use std::process::Command;
 // - We can't install into the system site-packages inside the main Python directory since
 //   we need the app dependencies to be in their own layer.
 // - Some packages are broken with `--user` installs when using relocated Python, and
-//   otherwise require other workarounds. eg: https://github.com/unbit/uwsgi/issues/2525
+//   otherwise require other workarounds. e.g.: https://github.com/unbit/uwsgi/issues/2525
 // - Poetry doesn't support `--user`: https://github.com/python-poetry/poetry/issues/1214
 // - PEP-405 style venvs are very lightweight and are also much more frequently
 //   used in the wild compared to `--user`, and therefore the better tested path.

--- a/src/layers/python.rs
+++ b/src/layers/python.rs
@@ -82,7 +82,7 @@ pub(crate) fn install_python(
                 |error| match error {
                     // If the request 404s then the most likely cause is that the user specified an
                     // invalid Python version. However, there is a chance there is an issue with the
-                    // S3 bucket (eg files removed, or bucket made private). To try and tell the two
+                    // S3 bucket (e.g. files removed, or bucket made private). To try and tell the two
                     // cases apart, we check whether the requested version included a patch component.
                     // If it did, then it's most likely user error, but if it didn't, then the patch
                     // version is the one we resolved, and so we know it should be valid.

--- a/src/layers/uv_dependencies.rs
+++ b/src/layers/uv_dependencies.rs
@@ -21,7 +21,7 @@ use std::process::Command;
 // - We can't install into the system site-packages inside the main Python directory since
 //   we need the app dependencies to be in their own layer.
 // - Some packages are broken with `--user` installs when using relocated Python, and
-//   otherwise require other workarounds. eg: https://github.com/unbit/uwsgi/issues/2525
+//   otherwise require other workarounds. e.g.: https://github.com/unbit/uwsgi/issues/2525
 // - uv doesn't support `--user`: https://github.com/astral-sh/uv/issues/2077
 // - PEP-405 style venvs are very lightweight and are also much more frequently
 //   used in the wild compared to `--user`, and therefore the better tested path.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -82,7 +82,7 @@ pub(crate) fn download_and_unpack_zstd_archive(
     destination: &Path,
 ) -> Result<(), DownloadUnpackArchiveError> {
     // TODO: (W-12613141) Add a timeout: https://docs.rs/ureq/latest/ureq/struct.AgentBuilder.html?search=timeout
-    // TODO: (W-12613168) Add retries for certain failure modes, eg: https://github.com/algesten/ureq/blob/05b9a82a380af013338c4f42045811fc15689a6b/src/error.rs#L39-L63
+    // TODO: (W-12613168) Add retries for certain failure modes, e.g.: https://github.com/algesten/ureq/blob/05b9a82a380af013338c4f42045811fc15689a6b/src/error.rs#L39-L63
     let response = ureq::get(uri)
         .call()
         .map_err(DownloadUnpackArchiveError::Request)?;

--- a/tests/django_test.rs
+++ b/tests/django_test.rs
@@ -199,7 +199,7 @@ fn django_staticfiles_misconfigured() {
                     This is most likely due to an issue in your application code or Django
                     configuration. See the log output above for more information.
                     
-                    If you are using the WhiteNoise package to optimize the serving of static
+                    If you are using the WhiteNoise package to optimise the serving of static
                     files with Django (recommended), check that your app is using the Django
                     config options shown here:
                     https://whitenoise.readthedocs.io/en/stable/django.html


### PR DESCRIPTION
- Use the British spelling "optimise" in the Django static files error, to
  match the spelling used in the rest of the buildpack's output.
- Drop the redundant "I/O Error:" prefix from the archive unpack errors, so
  they render the error the same way as the other I/O error handlers.
- Standardise on "e.g." rather than "eg" in code comments.

Making these changes in part to stop Claude reporting them when code
reviewing the repo for bugs/inconsistencies and other potential improvements.

GUS-W-23022354.
