### PR TITLE
Use `#[expect]` instead of `#[allow]` for Clippy lint exclusions

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -146,7 +146,7 @@ fn on_determine_package_manager_error(error: DeterminePackageManagerError) {
     }
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn on_requested_python_version_error(error: RequestedPythonVersionError) {
     const RECOMMEND_NOT_SPECIFYING_PATCH_MESSAGE: &str = indoc! {"
         We strongly recommend that you don't specify the Python patch


### PR DESCRIPTION
Unlike `#[allow]`, `#[expect]` (stable since Rust 1.81) emits a warning if
the lint stops firing, so the attribute flags itself as removable should the
lint no longer apply:
https://doc.rust-lang.org/rustc/lints/levels.html#expect

GUS-W-23022354.
