### PR TITLE
Improve `pip_oldest_python` test coverage

### DIFF
--- a/tests/fixtures/pip_oldest_python/requirements.txt
+++ b/tests/fixtures/pip_oldest_python/requirements.txt
@@ -1,0 +1,1 @@
+typing-extensions==4.15.0

--- a/tests/pip_test.rs
+++ b/tests/pip_test.rs
@@ -235,7 +235,7 @@ fn pip_oldest_python() {
         assert_empty!(context.pack_stderr);
         assert_contains!(
             context.pack_stdout,
-            indoc! {"
+            &formatdoc! {"
                 [Determining Python version]
                 Using Python version 3.10.0 specified in .python-version
                 
@@ -256,6 +256,18 @@ fn pip_oldest_python() {
 
                 [Installing Python]
                 Installing Python 3.10.0
+                
+                [Installing pip]
+                Installing pip {PIP_VERSION}
+                
+                [Installing dependencies using pip]
+                Creating virtual environment
+                Running 'pip install -r requirements.txt'
+                Collecting typing-extensions==4.15.0 (from -r requirements.txt (line 1))
+                  Downloading typing_extensions-4.15.0-py3-none-any.whl.metadata (3.3 kB)
+                Downloading typing_extensions-4.15.0-py3-none-any.whl (44 kB)
+                Installing collected packages: typing-extensions
+                Successfully installed typing-extensions-4.15.0
             "}
         );
     });


### PR DESCRIPTION
The test installed no package, so make it install a single package like the equivalent Poetry and uv tests.

GUS-W-23599352.