### PR TITLE
Add support for Python 3.14.7 and 3.13.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Python 3.14 version alias now resolves to Python 3.14.7. ([#604](https://github.com/heroku/buildpacks-python/pull/604))
+- The Python 3.13 version alias now resolves to Python 3.13.15. ([#604](https://github.com/heroku/buildpacks-python/pull/604))
+
 ## [6.5.5] - 2026-07-30
 
 ### Changed

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -24,8 +24,8 @@ pub(crate) const NEXT_UNRELEASED_PYTHON_3_MINOR_VERSION: u16 =
 pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 20);
 pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 15);
 pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 13);
-pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 14);
-pub(crate) const LATEST_PYTHON_3_14: PythonVersion = PythonVersion::new(3, 14, 6);
+pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 15);
+pub(crate) const LATEST_PYTHON_3_14: PythonVersion = PythonVersion::new(3, 14, 7);
 
 /// The Python version that was requested for a project.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2026/08/python-3147-31315/

Changelogs:
https://docs.python.org/release/3.14.7/whatsnew/changelog.html#python-3-14-7-final
https://docs.python.org/release/3.13.15/whatsnew/changelog.html#python-3-13-15-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/31052140670
https://github.com/heroku/heroku-buildpack-python/actions/runs/31052134976

GUS-W-20590575.
GUS-W-20590512.
