### PR TITLE
Add support for Python 3.12.14, 3.11.16 and 3.10.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Python 3.12 version alias now resolves to Python 3.12.14. ([#608](https://github.com/heroku/buildpacks-python/pull/608))
+- The Python 3.11 version alias now resolves to Python 3.11.16. ([#608](https://github.com/heroku/buildpacks-python/pull/608))
+- The Python 3.10 version alias now resolves to Python 3.10.21. ([#608](https://github.com/heroku/buildpacks-python/pull/608))
+
 ## [6.5.6] - 2026-08-05
 
 ### Changed

--- a/src/python_version.rs
+++ b/src/python_version.rs
@@ -21,9 +21,9 @@ pub(crate) const NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION: u16 = 14;
 pub(crate) const NEXT_UNRELEASED_PYTHON_3_MINOR_VERSION: u16 =
     NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION + 1;
 
-pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 20);
-pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 15);
-pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 13);
+pub(crate) const LATEST_PYTHON_3_10: PythonVersion = PythonVersion::new(3, 10, 21);
+pub(crate) const LATEST_PYTHON_3_11: PythonVersion = PythonVersion::new(3, 11, 16);
+pub(crate) const LATEST_PYTHON_3_12: PythonVersion = PythonVersion::new(3, 12, 14);
 pub(crate) const LATEST_PYTHON_3_13: PythonVersion = PythonVersion::new(3, 13, 15);
 pub(crate) const LATEST_PYTHON_3_14: PythonVersion = PythonVersion::new(3, 14, 7);
 


### PR DESCRIPTION
Release announcement:
https://blog.python.org/2026/08/python-31214-31116-31021/

Changelogs:
https://docs.python.org/release/3.12.14/whatsnew/changelog.html#python-3-12-14-final
https://docs.python.org/release/3.11.16/whatsnew/changelog.html#python-3-11-16-final
https://docs.python.org/release/3.10.21/whatsnew/changelog.html#python-3-10-21-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/31706365991
https://github.com/heroku/heroku-buildpack-python/actions/runs/31706373444
https://github.com/heroku/heroku-buildpack-python/actions/runs/31706380912

GUS-W-23845464.
GUS-W-23845466.
GUS-W-23845470.