### PR TITLE
Set the pip Dependabot cooldown to zero days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    # Override GitHub's default 3-day cooldown so manually-triggered runs pick up
+    # the latest versions immediately (the monthly schedule already reduces the
+    # chance of picking up a too-new release).
+    cooldown:
+      default-days: 0
     labels:
       - "dependencies"
       - "python"


### PR DESCRIPTION
GitHub now applies a default 3-day cooldown to Dependabot version updates, so a manually triggered run won't pick up versions released in the last 3 days. Our scheduled runs are only monthly, so the cooldown buys us little here while blocking manual runs from fetching the latest versions.

Set an explicit `cooldown` of `default-days: 0` on the `pip` package-ecosystem entry so pip updates are picked up immediately. Other ecosystems keep the default cooldown.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

GUS-W-24072946.